### PR TITLE
Support syntax for named states

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -273,12 +273,13 @@ Toggle Concepts</h2>
 
 			* For "sticky",
 				incrementing beyond the [=maximum state=] or decrementing below 0
-				does not change the toggle state.
+				does not change the [=toggle/state=].
 
 			* If the [=toggle/state=] before activation is an <<integer>>
 				that is higher than the [=toggle specifier/maximum state=],
 				or a <<custom-ident>> that is not in the list of [=toggle specifier/state names=],
-				then both incrementing and decrementing follow the specified.
+				then incrementing follows the specified overflow behavior,
+				and decrementing returns the toggle to the [=maximum state=].
 	</dl>
 
 	[=Toggle specifiers=] are created by the 'toggle-root' property;
@@ -419,7 +420,7 @@ Creating a Toggle: the 'toggle-root' property</h2>
 				If specified as a bracketed list of <<custom-ident>>s,
 				specifies the [=toggle specifier/state names=],
 				and sets the [=toggle specifier/maximum state=]
-				to the (zero-indexed) length of the list.
+				to the length of the list minus 1.
 				If omitted, the [=toggle specifier/maximum state=] is set to 1.
 
 			* The <<toggle-state>>, if specified,
@@ -625,7 +626,7 @@ Activating a Toggle: the 'toggle-trigger' property</h3>
 	<pre class=prod>
 		<df><<toggle-trigger>></dfn> = <<custom-ident>> <<trigger-action>>?
 		<dfn><<trigger-action>></dfn> =
-			prev | next |
+			[prev | next] <<integer [1, ∞]>>? |
 			set <<toggle-state>>
 	</pre>
 
@@ -667,10 +668,12 @@ Activating a Toggle: the 'toggle-trigger' property</h3>
 		: <dfn>event</dfn>
 		:: If unspecified, or specified as the keyword 'next',
 			indicates that this activation will increment
-			the [=toggle's=] current [=toggle/state=].
+			the [=toggle's=] current [=toggle/state=] by <<integer>> steps,
+			or a single step if <<integer>> is not specified.
 			If specified as the keyword 'prev',
 			indicates that this activation will decrement
-			the [=toggle's=] current [=toggle/state=].
+			the [=toggle's=] current [=toggle/state=] by <<integer>> steps,
+			or a single step if <<integer>> is not specified.
 			If specified with the keyword 'set' and a <<toggle-state>>,
 			indicates the exact [=toggle/state=]
 			that this activation will attempt to put the [=toggle=] into.
@@ -1045,6 +1048,7 @@ Scripting API</h2>
 	enum CSSToggleCycle {
 		"cycle",
 		"cycle-on",
+		"sticky",
 	}
 	</xmp>
 

--- a/index.bs
+++ b/index.bs
@@ -108,9 +108,28 @@ Toggle Concepts</h2>
 		:: A <<custom-ident>>.
 
 		: <dfn>state</dfn>
-		:: A non-negative integer:
+		::
+			A <<custom-ident>> or non-negative <<integer>>:
 			either 0 (the <dfn>inactive state</dfn>)
 			or a value 1 or higher (the <dfn lt="active state">active states</dfn>).
+			In order to <dfn lt="match state">match states</dfn>:
+
+			* If the [=toggle/state=] is specified as an <<integer>>,
+				and there is a corresponding <<custom-ident>> at that (zero-indexed)
+				position in the list of [=toggle/state names=],
+				then the [=toggle/state=] will match either
+				the specified <<integer>> or that <<custom-ident>>.
+
+			* If the [=toggle/state=] is specified as a <<custom-ident>> that
+				is available in the list of [=toggle/state names=],
+				then the [=toggle/state=] will match either
+				the specified <<custom-ident>>,
+				or the (zero-indexed) <<integer>> position of that <<custom-ident>>
+				in [=toggle/state names=].
+
+			* If there are no corresponding <<integer>> and <<custom-ident>> values,
+				an <<integer>> [=toggle/state=] will only match the same <<integer>>,
+				and a <<custom-ident>> [=toggle/state=] will only match the same <<custom-ident>>.
 
 		: <dfn>state names</dfn>
 		::
@@ -214,16 +233,16 @@ Toggle Concepts</h2>
 		:: A <<custom-ident>> specifying the [=toggle's=] [=toggle/name=].
 
 		: <dfn>initial state</dfn>
-		:: A non-negative integer
+		:: A non-negative integer or a <<custom-ident>>
 			specifying the [=toggle's=] initial [=toggle/state=] upon creation.
 
 		: <dfn>maximum state</dfn>
 		:: A positive integer
-			specifying the highest [=active state=] the [=toggle=] can reach.
+			specifying the highest [=active state=] the [=toggle=] can reach
+			throught default transitions.
 
 		: <dfn>state names</dfn>
-		::
-			A [=/list=] of state names,
+		:: A [=/list=] of state names,
 			each of which are <<custom-ident>>s,
 			assigned to the [=toggle=] initially upon creation.
 
@@ -235,11 +254,31 @@ Toggle Concepts</h2>
 		:: An enum (either "wide" or "narrow"),
 			specifying the [=toggle's=] initial [=toggle/scope=] upon creation.
 
-		: <dfn>sticky</dfn>
-		:: A [=boolean=] specifying how to react
-			when a [=toggle activation=] would push the [=toggle/state=] past the specified [=maximum state=]:
-			the state either stays within the [=active states=] and returns to 1 (if true)
-			or cycles back to the [=inactive state=] (if false).
+		: <dfn>overflow</dfn>
+		:: An enum (either "cycle" or "cycle-on" or "sticky"),
+			specifying how to react when a [=toggle activation=]
+			would increment the [=toggle/state=]
+			above the specified [=maximum state=],
+			or decrement the state below the (overflow-defined) minimum:
+
+			* For "cycle-on",
+				incrementing beyond the [=maximum state=]
+				returns the toggle to the first active state (1),
+				and decrementing below 1 returns the toggle to the [=maximum state=].
+
+			* For "cycle",
+				incrementing beyond the [=maximum state=]
+				returns the toggle to the inactive state (0),
+				and decrementing below 0 returns the toggle to the [=maximum state=].
+
+			* For "sticky",
+				incrementing beyond the [=maximum state=] or decrementing below 0
+				does not change the toggle state.
+
+			* If the [=toggle/state=] before activation is an <<integer>>
+				that is higher than the [=toggle specifier/maximum state=],
+				or a <<custom-ident>> that is not in the list of [=toggle specifier/state names=],
+				then both incrementing and decrementing follow the specified.
 	</dl>
 
 	[=Toggle specifiers=] are created by the 'toggle-root' property;
@@ -255,7 +294,7 @@ Toggle Concepts</h2>
 		a false [=toggle specifier/group=],
 		a [=toggle specifier/scope=] of "wide",
 		a [=toggle specifier/maximum state=] of 1,
-		and a false [=toggle specifier/sticky=].
+		and a [=toggle specifier/overflow=] of "cycle".
 
 		Note: This produces behavior similar to a checkbox.
 	</div>
@@ -337,13 +376,16 @@ Creating a Toggle: the 'toggle-root' property</h2>
 
 	<pre class=prod>
 		<dfn><<toggle-specifier>></dfn> =
-			<<cusstom-ident>>
+			<<custom-ident>>
 			[
-				[ <<integer [0, ∞]>> / ]? <<integer [1, ∞]>> ||
-				sticky ||
+				<<toggle-states>> [at <<toggle-state>>]? ||
+				<<toggle-overflow>> ||
 				group ||
 				self
 			]?
+		<dfn><<toggle-states>></dfn> = <<integer [1, ∞]>> | '[' <<custom-ident>>* ']'
+		<dfn><<toggle-state>></dfn> = <<integer [0, ∞]>> | <<custom-ident>>
+		<dfn><<toggle-overflow>></dfn> = cycle | cycle-on | sticky
 	</pre>
 
 	The 'toggle-root' property causes [=toggles=] to be created on an element,
@@ -354,7 +396,8 @@ Creating a Toggle: the 'toggle-root' property</h2>
 		<dd>
 			The element has no [=toggle specifiers=].
 
-			(This does not remove any [=toggles=] that have already been established on the element.)
+			(This does not remove any [=toggles=] that have already been established
+			on the element.)
 
 		<dt><dfn><<toggle-specifier>>#</dfn>
 		<dd>
@@ -371,20 +414,21 @@ Creating a Toggle: the 'toggle-root' property</h2>
 				specifies the [=toggle specifier/name=],
 				as the item's value.
 
-			* The first <<integer>>, if specified,
+			* The <<toggle-states>>, if specified as an <<integer>>,
+				specifies the [=toggle specifier/maximum state=].
+				If specified as a bracketed list of <<custom-ident>>s,
+				specifies the [=toggle specifier/state names=],
+				and sets the [=toggle specifier/maximum state=]
+				to the (zero-indexed) length of the list.
+				If omitted, the [=toggle specifier/maximum state=] is set to 1.
+
+			* The <<toggle-state>>, if specified,
 				specifies the [=toggle specifier/initial state=].
 				If omitted, it's set to 0.
 
-				It must be less than or equal to the second <<integer>>,
-				or else the declaration is invalid.
-
-			* The second <<integer>>, if specified,
-				specifies the [=toggle specifier/maximum state=].
-				If omitted, it's set to 1.
-
-			* The <dfn>sticky</dfn> keyword, if specified,
-				sets the [=toggle specifier/sticky=] boolean to true.
-				If omitted, it's set to false.
+			* The <<toggle-overflow>> keyword, if specified,
+				specifies the [=toggle specifier/overflow=] enum.
+				If omitted, it's set to "cycle".
 
 			* The <dfn>group</dfn> keyword, if specified,
 				sets the [=toggle specifier/group=] boolean to true.
@@ -419,10 +463,6 @@ Creating a Toggle: the 'toggle-root' property</h2>
 		The effect is identical to what was specified in the Introduction example,
 		except the markup is much simpler and more semantic.
 	</div>
-
-	Issue: TODO create the <css>toggle-states</css> property
-	that defines [=toggle/state names=] for a [=toggle=],
-	and amend the various properties to allow them to take a <<toggle-name>> instead of an <<integer>>.
 
 <h3 id='toggle-creation'>
 Toggle Creation Details</h3>
@@ -511,16 +551,16 @@ Linking Toggle States: the 'toggle-group' property</h3>
 				toggle-group: tab;
 			}
 			panel-tab {
-				/* Each tab creates a sticky toggle
+				/* Each tab creates a cycle-on toggle
 					(so once it's open, clicking again won't close it),
 					opts into the group,
 					and declares itself a toggle activator */
-				toggle: tab 1 group sticky;
+				toggle: tab 1 group cycle-on;
 			}
 			panel-tab:first-of-type {
 				/* The first tab also sets its initial state
 					to be active */
-				toggle: tab 1/1 group sticky;
+				toggle: tab 1 at 1 group cycle-on;
 			}
 			panel-tab:toggle(tab) {
 				/* styling for the active tab */
@@ -536,7 +576,7 @@ Linking Toggle States: the 'toggle-group' property</h3>
 		</xmp>
 
 		Clicking on any tab will increment its corresponding [=toggle's=] [=toggle/state=] from 0 to 1
-		(and the ''sticky'' keyword will keep it at 1 if activated multiple times),
+		(and the ''cycle-on'' keyword will keep it at 1 if activated multiple times),
 		while resetting the rest of the tabs' [=toggle/states=] to 0.
 		Each panel is [=in scope=] for the [=toggle=] defined by its preceding tab,
 		so it can respond to the [=toggle/state=] as well.
@@ -572,7 +612,7 @@ Activating a Toggle: the 'toggle-trigger' property</h3>
 
 	<pre class='propdef'>
 	Name: toggle-trigger
-	Value: none | [ <<custom-ident>> <<integer [0, ∞]>>? ]#
+	Value: none | <<toggle-trigger>>#
 	Initial: none
 	Applies to: elements without existing activation behavior (see prose)
 	Inherited: no
@@ -582,16 +622,29 @@ Activating a Toggle: the 'toggle-trigger' property</h3>
 	Animatable: no
 	</pre>
 
+	<pre class=prod>
+		<df><<toggle-trigger>></dfn> = <<custom-ident>> <<trigger-action>>?
+		<dfn><<trigger-action>></dfn> =
+			prev | next |
+			set <<toggle-state>>
+	</pre>
+
 	The 'toggle-trigger' property specifies that an element can be activated
 	to change the state of one or more [=toggles=].
 	It has the following values:
 
+	ISSUE: Consider adding support for an at-rule that defines machine states,
+	the available events to trigger from each state,
+	and the resulting state of each event.
+	In that case <<trigger-action>> would need to also accept custom events,
+	possibly marked by a new keyword or function.
+
 	<dl dfn-type=value dfn-for=toggle-trigger>
 		: <dfn>none</dfn>
 		::
-			The element does not manipulated any [=toggles=].
+			The element does not manipulate any [=toggles=].
 
-		: <dfn><<custom-ident>> <<integer [0, ∞]>>?</dfn>
+		: <<toggle-trigger>>
 		::
 			If the element already has existing activation behavior from the host language,
 			this value does nothing.
@@ -600,9 +653,8 @@ Activating a Toggle: the 'toggle-trigger' property</h3>
 			and when activated,
 			for each comma-separated entry in the list,
 			[=fires=] a [=toggle activation=]
-			with the given <<custom-ident>>
-			and, if an <<integer>> is specified,
-			a target state of that integer.
+			with the given <<custom-ident>> as a [=toggle activation/name=],
+			and the <<trigger-action>> [=event=], if specified.
 	</dl>
 
 	A <dfn for=CSS export>toggle activation</dfn> is a struct with the following items:
@@ -610,15 +662,18 @@ Activating a Toggle: the 'toggle-trigger' property</h3>
 	<dl dfn-for="toggle activation" export>
 		: <dfn>name</dfn>
 		:: The [=toggle/name=] of the [=toggle=]
-			this is intended activate.
+			this is intended to activate.
 
-		: <dfn>target state</dfn>
-		:: An optional non-negative integer.
-
-			If specified, gives the [=toggle/state=]
+		: <dfn>event</dfn>
+		:: If unspecified, or specified as the keyword 'next',
+			indicates that this activation will increment
+			the [=toggle's=] current [=toggle/state=].
+			If specified as the keyword 'prev',
+			indicates that this activation will decrement
+			the [=toggle's=] current [=toggle/state=].
+			If specified with the keyword 'set' and a <<toggle-state>>,
+			indicates the exact [=toggle/state=]
 			that this activation will attempt to put the [=toggle=] into.
-			If unspecified,
-			indicates that this activation will increment the [=toggle's=] current [=toggle/state=].
 	</dl>
 
 	<div algorithm>
@@ -641,16 +696,10 @@ Activating a Toggle: the 'toggle-trigger' property</h3>
 				Otherwise, let |specifier| be a new [=default toggle specifier=]
 				for |activation|'s [=toggle activation/name=].
 
-			3. If |activation|'s [=target state=] is specified,
-				set |toggle|'s [=toggle/state=] to the smaller of the [=target state=]
-				and |specifier|'s [=toggle specifier/maximum state=].
-
-				Otherwise,
-				increment |toggle|'s [=toggle/state=] by 1.
-				If the [=toggle/state=] is now higher than |specifier|'s [=toggle specifier/maximum state=],
-				then set the [=toggle/state=] to 1
-				if |specifier|'s [=toggle specifier/sticky=] flag is true,
-				and to 0 if it's false.
+			3. Set |toggle|'s [=toggle/state=] to the result of
+				the specified [=toggle activation/event=],
+				following the specified [=toggle specifier/overflow=] behavior
+				when incrementing or decrementing.
 
 			4. If |toggle|'s [=toggle/state=] is now greater than zero
 				and |toggle| is [=in a toggle group=],
@@ -742,7 +791,7 @@ Accessibility Implications of Toggles</h3>
 			and communicate in the a11y tree that it's a checkbox/radio/etc
 		* we can infer what type of control it is
 			by examining the properties of the toggle:
-			if it's part of a group, sticky, etc.
+			if it's part of a group, cycle-on, etc.
 		* if 'toggle-visibility' is in use,
 			we can also automatically infer all the tab-set ARIA roles
 	</div>
@@ -771,14 +820,16 @@ Selecting Elements Based on Toggle State: the '':toggle()'' pseudo-class</h2>
 	the <dfn>:toggle()</dfn> pseudo-class:
 
 	<pre class=prod>
-		:toggle( <<custom-ident>> <<integer>>? )
+		:toggle( <<custom-ident>> <<toggle-state>>? )
 	</pre>
 
 	An element matches '':toggle()''
 	if the element is [=in scope=] for a [=toggle=]
 	with the [=toggle/name=] given by <<custom-ident>>,
-	and either the [=toggle's=] [=toggle/state=] matches the provided <<integer>>,
-	or the <<integer>> is omitted and the [=toggle=] is in any [=active state=].
+	and either the [=toggle's=] [=toggle/state=]
+	[=toggle/match states|matches=] the provided <<toggle-state>>,
+	or the <<toggle-state>> is omitted
+	and the [=toggle=] is in any [=active state=].
 
 	<div class=example>
 		For example, if a [=toggle=] named "used"
@@ -802,7 +853,7 @@ Selecting Elements Based on Toggle State: the '':toggle()'' pseudo-class</h2>
 
 		<pre class=lang-css>
 			.tristate-check {
-				toggle: check 0/2;
+				toggle: check 2 at 0;
 			}
 			.tristate-check:toggle(check 1) {
 				/* "checked" styles */
@@ -894,7 +945,7 @@ Automatically Hiding With A Toggle</h2>
 			If the element starts being [=relevant to the user=],
 			it [=fires=] a [=toggle activation=],
 			with a [=toggle activation/name=] of the given <<toggle-name>>
-			and a [=toggle activation/target state=] of 1.
+			and a [=toggle activation/event=] of ‘set 1’.
 
 			Note: If the [=toggle=] is in an [=active state=],
 			or the element can't see the specified [=toggle=] at all,
@@ -993,7 +1044,7 @@ Scripting API</h2>
 
 	enum CSSToggleCycle {
 		"cycle",
-		"sticky",
+		"cycle-on",
 	}
 	</xmp>
 

--- a/index.html
+++ b/index.html
@@ -1,17 +1,14 @@
 <!doctype html><html lang="en">
  <head>
   <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
-  <title>CSS Toggles</title>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport">
-  <meta content="exploring" name="csswg-work-status">
+  <title>CSS Toggles</title>
   <meta content="UD" name="w3c-status">
-  <meta content="This specification defines a way to associate a toggleable state with an element which can be used in Selectors to select an element, and declarative ways to set and modify the state on the element." name="abstract">
-  <link href="../default.css" rel="stylesheet" type="text/css">
-  <link href="../csslogo.ico" rel="shortcut icon" type="image/x-icon">
-  <link href="https://www.w3.org/StyleSheets/TR/2021/W3C-UD" rel="stylesheet" type="text/css">
-  <meta content="Bikeshed version 15125077e, updated Fri Jan 14 14:49:38 2022 -0800" name="generator">
+  <link href="https://www.w3.org/StyleSheets/TR/2021/W3C-UD" rel="stylesheet">
+  <link href="https://www.w3.org/2008/site/images/favicon.ico" rel="icon">
+  <meta content="Bikeshed version dfbc2b297, updated Thu Nov 11 15:52:32 2021 -0800" name="generator">
   <link href="http://tabatkins.github.io/css-toggle/" rel="canonical">
-  <meta content="ca579d91b27506c36b08f7a49b8e6b0dca7b9f30" name="document-revision">
+  <meta content="0fab36fead319242a7406d3b0604c5d21ece68de" name="document-revision">
 <style>/* style-autolinks */
 
 .css.css, .property.property, .descriptor.descriptor {
@@ -327,6 +324,10 @@ dfn > a.self-link::before      { content: "#"; }
 </style>
 <style>/* style-syntax-highlighting */
 
+            pre.idl.highlight {
+                background: var(--borderedblock-bg, var(--def-bg));
+            }
+            
 code.highlight { padding: .1em; border-radius: .3em; }
 pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em 0; overflow: auto; border-radius: 0; }
 
@@ -589,7 +590,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">CSS Toggles</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="profile-and-date"><span class="content">Unofficial Proposal Draft, <time class="dt-updated" datetime="2022-01-26">26 January 2022</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="profile-and-date"><span class="content">Unofficial Proposal Draft, <time class="dt-updated" datetime="2022-04-25">25 April 2022</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -615,7 +616,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
 (such as HTML and XML)
 on screen, on paper, etc. 
   </div>
-  <h2 class="no-num no-toc no-ref heading settled" id="status"><span class="content">Status of this document</span></h2>
+  <h2 class="no-num no-toc no-ref heading settled" id="sotd"><span class="content">Status of this document</span></h2>
   <div data-fill-with="status">
    <p><em>This section describes the status of this document at the time of its publication.
 	Other documents may supersede this document.
@@ -640,7 +641,11 @@ on screen, on paper, etc.
   <nav data-fill-with="table-of-contents" id="toc">
    <h2 class="no-num no-toc no-ref" id="contents">Table of Contents</h2>
    <ol class="toc" role="directory">
-    <li><a href="#introduction"><span class="secno">1</span> <span class="content"> Introduction</span></a>
+    <li>
+     <a href="#introduction"><span class="secno">1</span> <span class="content"> Introduction</span></a>
+     <ol class="toc">
+      <li><a href="#terminology"><span class="secno">1.1</span> <span class="content">Terminology</span></a>
+     </ol>
     <li>
      <a href="#toggles"><span class="secno">2</span> <span class="content"> Toggle Concepts</span></a>
      <ol class="toc">
@@ -649,10 +654,11 @@ on screen, on paper, etc.
     <li>
      <a href="#toggle-root-property"><span class="secno">3</span> <span class="content"> Creating a Toggle: the <span class="property">toggle-root</span> property</span></a>
      <ol class="toc">
-      <li><a href="#toggle-group-property"><span class="secno">3.1</span> <span class="content"> Linking Toggle States: the <span class="property">toggle-group</span> property</span></a>
-      <li><a href="#toggle-trigger-property"><span class="secno">3.2</span> <span class="content"> Activating a Toggle: the <span class="property">toggle-trigger</span> property</span></a>
-      <li><a href="#toggle-property"><span class="secno">3.3</span> <span class="content"> Creating and Activating Toggles Simultaneously: the <span class="property">toggle</span> shorthand</span></a>
-      <li><a href="#a11y"><span class="secno">3.4</span> <span class="content"> Accessibility Implications of Toggles</span></a>
+      <li><a href="#toggle-creation"><span class="secno">3.1</span> <span class="content"> Toggle Creation Details</span></a>
+      <li><a href="#toggle-group-property"><span class="secno">3.2</span> <span class="content"> Linking Toggle States: the <span class="property">toggle-group</span> property</span></a>
+      <li><a href="#toggle-trigger-property"><span class="secno">3.3</span> <span class="content"> Activating a Toggle: the <span class="property">toggle-trigger</span> property</span></a>
+      <li><a href="#toggle-property"><span class="secno">3.4</span> <span class="content"> Creating and Activating Toggles Simultaneously: the <span class="property">toggle</span> shorthand</span></a>
+      <li><a href="#a11y"><span class="secno">3.5</span> <span class="content"> Accessibility Implications of Toggles</span></a>
      </ol>
     <li><a href="#checked-pseudoclass"><span class="secno">4</span> <span class="content"> Selecting Elements Based on Toggle State: the <span class="css">:toggle()</span> pseudo-class</span></a>
     <li><a href="#toggle-visibility-property"><span class="secno">5</span> <span class="content"> Automatically Hiding With A Toggle</span></a>
@@ -681,6 +687,7 @@ on screen, on paper, etc.
       <li><a href="#normative"><span class="secno"></span> <span class="content">Normative References</span></a>
      </ol>
     <li><a href="#property-index"><span class="secno"></span> <span class="content">Property Index</span></a>
+    <li><a href="#idl-index"><span class="secno"></span> <span class="content">IDL Index</span></a>
     <li><a href="#issues-index"><span class="secno"></span> <span class="content">Issues Index</span></a>
    </ol>
   </nav>
@@ -713,21 +720,31 @@ input[type='checkbox']:checked + span {
 		one can cross out ingredients as they’re used in the recipe
 		by simply clicking on them.</p>
    </div>
-   <p>This module generalizes this ability and allows it to be applied to any element via CSS.</p>
+   <p>This module generalizes this ability and allows it to be applied to any element via CSS,
+	so authors do not have to abuse host language semantics for styling purposes.
+	It also defines how to infer reasonable accessibility semantics
+	from the toggle structure,
+	making it simpler and more reliable
+	to produce accessible pages
+	using these sorts of basic interactivity
+	without the author having to manually annotate a page
+	with ARIA attributes or similar.</p>
+   <h3 class="heading settled" data-level="1.1" id="terminology"><span class="secno">1.1. </span><span class="content">Terminology</span><a class="self-link" href="#terminology"></a></h3>
    <p>Any element can become a <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="toggle-root">toggle root</dfn>,
-	meaning it hosts one or more <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle">toggles</a>,
-	each of which has a name,
+	meaning it hosts one or more <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle">toggles</a>.
+	Each <span id="ref-for-css-toggle①">toggle</span> has a name,
 	a value between 0 and some maximum,
 	and a few other bits of metadata,
-	via the <a class="property css" data-link-type="property" href="#propdef-toggle-root" id="ref-for-propdef-toggle-root">toggle-root</a> property.
+	all of which can be set via the <a class="property" data-link-type="propdesc" href="#propdef-toggle-root" id="ref-for-propdef-toggle-root">toggle-root</a> property.
 	The toggle is visible to the <a data-link-type="dfn" href="#toggle-root" id="ref-for-toggle-root">toggle root</a>,
 	its descendants,
 	and possibly its siblings and their descendants
 	(if the toggle says they can);
-	any element that can "see" a <span id="ref-for-css-toggle①">toggle</span> can use the <a class="css" data-link-type="maybe" href="#selectordef-toggle" id="ref-for-selectordef-toggle">:toggle()</a> pseudo-class.</p>
-   <p>Any element that can see a <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle②">toggle</a> can also <em>trigger</em> a toggle,
+	any element that can "see" a <span id="ref-for-css-toggle②">toggle</span> can use the <a class="css" data-link-type="maybe" href="#selectordef-toggle" id="ref-for-selectordef-toggle">:toggle()</a> pseudo-class
+	to select the element based on the toggle’s value.</p>
+   <p>Any element that can see a <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle③">toggle</a> can also <em>trigger</em> the toggle,
 	changing its value when the element is "activated",
-	via the <a class="property css" data-link-type="property" href="#propdef-toggle-trigger" id="ref-for-propdef-toggle-trigger">toggle-trigger</a> property.
+	via the <a class="property" data-link-type="propdesc" href="#propdef-toggle-trigger" id="ref-for-propdef-toggle-trigger">toggle-trigger</a> property.
 	This means you can have elements that self-trigger their own toggle,
 	like checkboxes,
 	but also have toggles that are visible to wide sections of a page
@@ -746,38 +763,42 @@ input[type='checkbox']:checked + span {
    <dl>
     <dt data-md><dfn class="dfn-paneled" data-dfn-for="toggle" data-dfn-type="dfn" data-export id="toggle-name">name</dfn>
     <dd data-md>
-     <p>A <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string">string</a>.</p>
-     <p>In CSS,
-this name is provided as a <a class="production css" data-link-type="type" href="#typedef-toggle-toggle-name" id="ref-for-typedef-toggle-toggle-name">&lt;toggle-name></a>,
-which is either a <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#identifier-value" id="ref-for-identifier-value">&lt;custom-ident></a> or as a <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#string-value" id="ref-for-string-value">&lt;string></a>;
-in either case, the item’s value is the <a data-link-type="dfn" href="#toggle-name" id="ref-for-toggle-name">name</a>.</p>
-<pre class="prod"><dfn class="dfn-paneled" data-dfn-for="toggle" data-dfn-type="type" data-export id="typedef-toggle-toggle-name"><a class="production" data-link-type="type" href="#typedef-toggle-toggle-name" id="ref-for-typedef-toggle-toggle-name①">&lt;toggle-name></a></dfn> = <a class="production" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#identifier-value" id="ref-for-identifier-value①">&lt;custom-ident></a> <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one" id="ref-for-comb-one">|</a> <a class="production" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#string-value" id="ref-for-string-value①">&lt;string></a>
-</pre>
-     <div class="example" id="example-00eb57a7">
-      <a class="self-link" href="#example-00eb57a7"></a> For example, <span class="css">foo</span> and <span class="css">"foo"</span> are both valid ways
-	to refer to the same toggle name. 
-      <p>However, <span class="css">foo</span> and <span class="css">FOO</span> are two different names,
-	since they’re not <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string-is" id="ref-for-string-is">identical to</a> each other.</p>
-     </div>
+     <p>A <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#identifier-value" id="ref-for-identifier-value">&lt;custom-ident></a>.</p>
     <dt data-md><dfn class="dfn-paneled" data-dfn-for="toggle" data-dfn-type="dfn" data-export id="toggle-state">state</dfn>
     <dd data-md>
-     <p>A non-negative integer:
+     <p>A <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#identifier-value" id="ref-for-identifier-value①">&lt;custom-ident></a> or non-negative <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#integer-value" id="ref-for-integer-value">&lt;integer></a>:
 either 0 (the <dfn class="dfn-paneled" data-dfn-for="toggle" data-dfn-type="dfn" data-export id="toggle-inactive-state">inactive state</dfn>)
-or a value 1 or higher (the <dfn class="dfn-paneled" data-dfn-for="toggle" data-dfn-type="dfn" data-export data-lt="active state" id="toggle-active-state">active states</dfn>).</p>
+or a value 1 or higher (the <dfn class="dfn-paneled" data-dfn-for="toggle" data-dfn-type="dfn" data-export data-lt="active state" id="toggle-active-state">active states</dfn>).
+In order to <dfn class="dfn-paneled" data-dfn-for="toggle" data-dfn-type="dfn" data-export data-lt="match state" id="toggle-match-state">match states</dfn>:</p>
+     <ul>
+      <li data-md>
+       <p>If the <a data-link-type="dfn" href="#toggle-state" id="ref-for-toggle-state">state</a> is specified as an <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#integer-value" id="ref-for-integer-value①">&lt;integer></a>,
+and there is a corresponding <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#identifier-value" id="ref-for-identifier-value②">&lt;custom-ident></a> at that (zero-indexed)
+position in the list of <a data-link-type="dfn" href="#toggle-state-names" id="ref-for-toggle-state-names">state names</a>,
+then the <span id="ref-for-toggle-state①">state</span> will match either
+the specified <span class="production" id="ref-for-integer-value②">&lt;integer></span> or that <span class="production" id="ref-for-identifier-value③">&lt;custom-ident></span>.</p>
+      <li data-md>
+       <p>If the <a data-link-type="dfn" href="#toggle-state" id="ref-for-toggle-state②">state</a> is specified as a <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#identifier-value" id="ref-for-identifier-value④">&lt;custom-ident></a> that
+is available in the list of <a data-link-type="dfn" href="#toggle-state-names" id="ref-for-toggle-state-names①">state names</a>,
+then the <span id="ref-for-toggle-state③">state</span> will match either
+the specified <span class="production" id="ref-for-identifier-value⑤">&lt;custom-ident></span>,
+or the (zero-indexed) <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#integer-value" id="ref-for-integer-value③">&lt;integer></a> position of that <span class="production" id="ref-for-identifier-value⑥">&lt;custom-ident></span> in <span id="ref-for-toggle-state-names②">state names</span>.</p>
+      <li data-md>
+       <p>If there are no corresponding <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#integer-value" id="ref-for-integer-value④">&lt;integer></a> and <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#identifier-value" id="ref-for-identifier-value⑦">&lt;custom-ident></a> values,
+an <span class="production" id="ref-for-integer-value⑤">&lt;integer></span> <a data-link-type="dfn" href="#toggle-state" id="ref-for-toggle-state④">state</a> will only match the same <span class="production" id="ref-for-integer-value⑥">&lt;integer></span>,
+and a <span class="production" id="ref-for-identifier-value⑧">&lt;custom-ident></span> <span id="ref-for-toggle-state⑤">state</span> will only match the same <span class="production" id="ref-for-identifier-value⑨">&lt;custom-ident></span>.</p>
+     </ul>
     <dt data-md><dfn class="dfn-paneled" data-dfn-for="toggle" data-dfn-type="dfn" data-export id="toggle-state-names">state names</dfn>
     <dd data-md>
      <p>A <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list">list</a> of state names,
-each of which are <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string①">strings</a>.</p>
-     <p>Like the toggle’s <a data-link-type="dfn" href="#toggle-name" id="ref-for-toggle-name①">name</a>,
-in CSS they are <a class="production css" data-link-type="type" href="#typedef-toggle-toggle-name" id="ref-for-typedef-toggle-toggle-name②">&lt;toggle-name></a>s,
-with the value of the item giving the state name.</p>
+each of which are <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#identifier-value" id="ref-for-identifier-value①⓪">&lt;custom-ident></a>s.</p>
     <dt data-md><dfn class="dfn-paneled" data-dfn-for="toggle" data-dfn-type="dfn" data-export id="toggle-group">group</dfn>
     <dd data-md>
-     <p>A <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#boolean" id="ref-for-boolean">boolean</a> indicating whether the <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle③">toggle</a> is part of a <a data-link-type="dfn" href="#css-toggle-group" id="ref-for-css-toggle-group">toggle group</a> (of the same <a data-link-type="dfn" href="#toggle-name" id="ref-for-toggle-name②">name</a>)
+     <p>A <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#boolean" id="ref-for-boolean">boolean</a> indicating whether the <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle④">toggle</a> is part of a <a data-link-type="dfn" href="#css-toggle-group" id="ref-for-css-toggle-group">toggle group</a> (of the same <a data-link-type="dfn" href="#toggle-name" id="ref-for-toggle-name">name</a>)
 or not.</p>
     <dt data-md><dfn class="dfn-paneled" data-dfn-for="toggle" data-dfn-type="dfn" data-export id="toggle-scope">scope</dfn>
     <dd data-md>
-     <p>A <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string②">string</a> enum indicating what sort of <a data-link-type="dfn" href="#toggle-scope" id="ref-for-toggle-scope">scope</a> the <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle④">toggle</a> uses.
+     <p>An enum indicating what sort of <a data-link-type="dfn" href="#toggle-scope" id="ref-for-toggle-scope">scope</a> the <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle⑤">toggle</a> uses.
 It can have two values:</p>
      <ul>
       <li data-md>
@@ -787,9 +808,9 @@ and its following siblings and their descendants).</p>
        <p><dfn data-dfn-for="toggle" data-dfn-type="dfn" data-export id="toggle-narrow">"narrow"<a class="self-link" href="#toggle-narrow"></a></dfn>, indicating the toggle has <a data-link-type="dfn" href="#toggle-narrow-scope" id="ref-for-toggle-narrow-scope">narrow scope</a> (it’s visible to the element and its descendants only).</p>
      </ul>
    </dl>
-   <p><a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle⑤">Toggles</a> are persistent state on an element,
+   <p><a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle⑥">Toggles</a> are persistent state on an element,
 	and are not <em>directly</em> affected by any CSS properties.
-	An element can have any number of <span id="ref-for-css-toggle⑥">toggles</span>.</p>
+	An element can have any number of <span id="ref-for-css-toggle⑦">toggles</span>.</p>
    <hr>
    <p>A <dfn class="dfn-paneled" data-dfn-for="CSS" data-dfn-type="dfn" data-export id="css-toggle-group">toggle group</dfn> is a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#struct" id="ref-for-struct①">struct</a> associated with an <a data-link-type="dfn" href="https://drafts.csswg.org/css-display-3/#elements" id="ref-for-elements①">element</a>,
 	which groups together toggles of the same name
@@ -797,14 +818,10 @@ and its following siblings and their descendants).</p>
    <dl>
     <dt data-md><dfn class="dfn-paneled" data-dfn-for="toggle group" data-dfn-type="dfn" data-export id="toggle-group-name">name</dfn>
     <dd data-md>
-     <p>A <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string③">string</a>,
-starting with two dashes (U+002D HYPHEN-MINUS).</p>
-     <p>Like a toggle’s <a data-link-type="dfn" href="#toggle-name" id="ref-for-toggle-name③">name</a>,
-in CSS they are given by a <a class="production css" data-link-type="type" href="#typedef-toggle-toggle-name" id="ref-for-typedef-toggle-toggle-name③">&lt;toggle-name></a>,
-with the value of the item giving the name.</p>
+     <p>A <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#identifier-value" id="ref-for-identifier-value①①">&lt;custom-ident></a>.</p>
     <dt data-md><dfn class="dfn-paneled" data-dfn-for="toggle group" data-dfn-type="dfn" data-export id="toggle-group-scope">scope</dfn>
     <dd data-md>
-     <p>A <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string④">string</a> enum indicating what sort of <a data-link-type="dfn" href="#toggle-scope" id="ref-for-toggle-scope①">scope</a> the <a data-link-type="dfn" href="#css-toggle-group" id="ref-for-css-toggle-group②">toggle group</a> uses.
+     <p>An enum indicating what sort of <a data-link-type="dfn" href="#toggle-scope" id="ref-for-toggle-scope①">scope</a> the <a data-link-type="dfn" href="#css-toggle-group" id="ref-for-css-toggle-group②">toggle group</a> uses.
 It can have two values:</p>
      <ul>
       <li data-md>
@@ -814,92 +831,109 @@ and its following siblings and their descendants).</p>
        <p><dfn data-dfn-for="toggle group" data-dfn-type="dfn" data-export id="toggle-group-narrow">"narrow"<a class="self-link" href="#toggle-group-narrow"></a></dfn>, indicating the toggle has <a data-link-type="dfn" href="#toggle-narrow-scope" id="ref-for-toggle-narrow-scope①">narrow scope</a> (it’s visible to the element and its descendants only).</p>
      </ul>
    </dl>
-   <p><a data-link-type="dfn" href="#css-toggle-group" id="ref-for-css-toggle-group③">Toggle groups</a> are created by the <a class="property css" data-link-type="property" href="#propdef-toggle-group" id="ref-for-propdef-toggle-group">toggle-group</a> property;
+   <p><a data-link-type="dfn" href="#css-toggle-group" id="ref-for-css-toggle-group③">Toggle groups</a> are created by the <a class="property" data-link-type="propdesc" href="#propdef-toggle-group" id="ref-for-propdef-toggle-group">toggle-group</a> property;
 	they are not persistent state on an element.
 	An element can have any number of <span id="ref-for-css-toggle-group④">toggle groups</span>.</p>
-   <p>A <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle⑦">toggle</a> is <dfn class="dfn-paneled" data-dfn-for="toggle" data-dfn-type="dfn" data-export id="toggle-in-a-toggle-group">in a toggle group</dfn> if its <a data-link-type="dfn" href="#toggle-group" id="ref-for-toggle-group">group</a> boolean is true;
-	if the element is <a data-link-type="dfn" href="#toggle-in-scope" id="ref-for-toggle-in-scope">in scope</a> for a <a data-link-type="dfn" href="#css-toggle-group" id="ref-for-css-toggle-group⑤">toggle group</a> with the same <a data-link-type="dfn" href="#toggle-name" id="ref-for-toggle-name④">name</a> as the <span id="ref-for-css-toggle⑧">toggle</span>,
+   <p>A <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle⑧">toggle</a> is <dfn class="dfn-paneled" data-dfn-for="toggle" data-dfn-type="dfn" data-export id="toggle-in-a-toggle-group">in a toggle group</dfn> if its <a data-link-type="dfn" href="#toggle-group" id="ref-for-toggle-group">group</a> boolean is true;
+	if the element is <a data-link-type="dfn" href="#toggle-in-scope" id="ref-for-toggle-in-scope">in scope</a> for a <a data-link-type="dfn" href="#css-toggle-group" id="ref-for-css-toggle-group⑤">toggle group</a> with the same <a data-link-type="dfn" href="#toggle-name" id="ref-for-toggle-name①">name</a> as the <span id="ref-for-css-toggle⑨">toggle</span>,
 	it’s in that group;
-	otherwise, it’s in a document-wide <dfn data-dfn-for="CSS" data-dfn-type="dfn" data-export id="css-implicit-toggle-group">implicit toggle group<a class="self-link" href="#css-implicit-toggle-group"></a></dfn> with the same <span id="ref-for-toggle-name⑤">name</span>.</p>
+	otherwise, it’s in a document-wide <dfn data-dfn-for="CSS" data-dfn-type="dfn" data-export id="css-implicit-toggle-group">implicit toggle group<a class="self-link" href="#css-implicit-toggle-group"></a></dfn> with the same <span id="ref-for-toggle-name②">name</span>.</p>
    <hr>
-   <p><a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle⑨">Toggles</a> and <a data-link-type="dfn" href="#css-toggle-group" id="ref-for-css-toggle-group⑥">toggle groups</a> have a scope,
+   <p><a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle①⓪">Toggles</a> and <a data-link-type="dfn" href="#css-toggle-group" id="ref-for-css-toggle-group⑥">toggle groups</a> have a scope,
 	defining what additional elements
-	(beyond the element the <span id="ref-for-css-toggle①⓪">toggle</span>/<span id="ref-for-css-toggle-group⑦">toggle group</span> is on)
-	can see and interact with the <span id="ref-for-css-toggle①①">toggle</span>/<span id="ref-for-css-toggle-group⑧">toggle group</span>.</p>
-   <p>If the <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle①②">toggle</a> (<a data-link-type="dfn" href="#css-toggle-group" id="ref-for-css-toggle-group⑨">toggle group</a>) has <dfn class="dfn-paneled" data-dfn-for="toggle" data-dfn-type="dfn" data-export id="toggle-wide-scope">wide scope</dfn>,
+	(beyond the element the <span id="ref-for-css-toggle①①">toggle</span>/<span id="ref-for-css-toggle-group⑦">toggle group</span> is on)
+	can see and interact with the <span id="ref-for-css-toggle①②">toggle</span>/<span id="ref-for-css-toggle-group⑧">toggle group</span>.</p>
+   <p>If the <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle①③">toggle</a> (<a data-link-type="dfn" href="#css-toggle-group" id="ref-for-css-toggle-group⑨">toggle group</a>) has <dfn class="dfn-paneled" data-dfn-for="toggle" data-dfn-type="dfn" data-export id="toggle-wide-scope">wide scope</dfn>,
 	it’s visible to the element it’s defined on,
 	its descendants
 	its <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-tree-following" id="ref-for-concept-tree-following">following</a> <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-tree-sibling" id="ref-for-concept-tree-sibling">siblings</a>,
 	and their <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-tree-descendant" id="ref-for-concept-tree-descendant">descendants</a>.</p>
-   <p>If the <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle①③">toggle</a> (<a data-link-type="dfn" href="#css-toggle-group" id="ref-for-css-toggle-group①⓪">toggle group</a>) has <dfn class="dfn-paneled" data-dfn-for="toggle" data-dfn-type="dfn" data-export id="toggle-narrow-scope">narrow scope</dfn>,
+   <p>If the <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle①④">toggle</a> (<a data-link-type="dfn" href="#css-toggle-group" id="ref-for-css-toggle-group①⓪">toggle group</a>) has <dfn class="dfn-paneled" data-dfn-for="toggle" data-dfn-type="dfn" data-export id="toggle-narrow-scope">narrow scope</dfn>,
 	it’s visible to the element it’s defined on
 	and its descendants.</p>
-   <p><a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle①④">Toggles</a> of the same <a data-link-type="dfn" href="#toggle-name" id="ref-for-toggle-name⑥">name</a> "shadow" earlier ones;
-	if multiple toggles of a given <span id="ref-for-toggle-name⑦">name</span> would have overlapping scopes,
-	an element is only <dfn class="dfn-paneled" data-dfn-for="toggle" data-dfn-type="dfn" data-export id="toggle-in-scope">in scope</dfn> for the <span id="ref-for-css-toggle①⑤">toggle</span> created by the nearest <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-tree-preceding" id="ref-for-concept-tree-preceding">preceding</a> element in <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-tree-order" id="ref-for-concept-tree-order">tree order</a>.
+   <p><a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle①⑤">Toggles</a> of the same <a data-link-type="dfn" href="#toggle-name" id="ref-for-toggle-name③">name</a> "shadow" earlier ones;
+	if multiple toggles of a given <span id="ref-for-toggle-name④">name</span> would have overlapping scopes,
+	an element is only <dfn class="dfn-paneled" data-dfn-for="toggle" data-dfn-type="dfn" data-export id="toggle-in-scope">in scope</dfn> for the <span id="ref-for-css-toggle①⑥">toggle</span> created by the nearest <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-tree-preceding" id="ref-for-concept-tree-preceding">preceding</a> element in <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-tree-order" id="ref-for-concept-tree-order">tree order</a>.
 	The same applies to <a data-link-type="dfn" href="#css-toggle-group" id="ref-for-css-toggle-group①①">toggle groups</a>.
-	However, <span id="ref-for-css-toggle①⑥">toggles</span> and <span id="ref-for-css-toggle-group①②">toggle groups</span> do not interfere with each other’s scopes;
-	an element can "see past" a <span id="ref-for-css-toggle①⑦">toggle</span> to find a <span id="ref-for-css-toggle-group①③">toggle group</span> of the same name it’s <a data-link-type="dfn" href="#toggle-in-scope" id="ref-for-toggle-in-scope①">in scope</a> for,
+	However, <span id="ref-for-css-toggle①⑦">toggles</span> and <span id="ref-for-css-toggle-group①②">toggle groups</span> do not interfere with each other’s scopes;
+	an element can "see past" a <span id="ref-for-css-toggle①⑧">toggle</span> to find a <span id="ref-for-css-toggle-group①③">toggle group</span> of the same name it’s <a data-link-type="dfn" href="#toggle-in-scope" id="ref-for-toggle-in-scope①">in scope</a> for,
 	and vice versa.</p>
    <hr>
    <p>A <dfn class="dfn-paneled" data-dfn-for="toggle" data-dfn-type="dfn" data-export id="toggle-toggle-specifier">toggle specifier</dfn> is a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#struct" id="ref-for-struct②">struct</a> associated with an element,
-	defining the initial state of a <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle①⑧">toggle</a> if one needs to be created on the element,
+	defining the initial state of a <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle①⑨">toggle</a> if one needs to be created on the element,
 	and how to respond to a <a data-link-type="dfn" href="#css-toggle-activation" id="ref-for-css-toggle-activation">toggle activation</a>.
 	It has the following <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#struct-item" id="ref-for-struct-item②">items</a>:</p>
    <dl>
     <dt data-md><dfn class="dfn-paneled" data-dfn-for="toggle specifier" data-dfn-type="dfn" data-export id="toggle-specifier-name">name</dfn>
     <dd data-md>
-     <p>A <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string⑤">string</a> specifying the <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle①⑨">toggle’s</a> <a data-link-type="dfn" href="#toggle-name" id="ref-for-toggle-name⑧">name</a>.</p>
+     <p>A <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#identifier-value" id="ref-for-identifier-value①②">&lt;custom-ident></a> specifying the <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle②⓪">toggle’s</a> <a data-link-type="dfn" href="#toggle-name" id="ref-for-toggle-name⑤">name</a>.</p>
     <dt data-md><dfn class="dfn-paneled" data-dfn-for="toggle specifier" data-dfn-type="dfn" data-export id="toggle-specifier-initial-state">initial state</dfn>
     <dd data-md>
-     <p>A non-negative integer
-specifying the <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle②⓪">toggle’s</a> initial <a data-link-type="dfn" href="#toggle-state" id="ref-for-toggle-state">state</a> upon creation.</p>
-    <dt data-md><dfn class="dfn-paneled" data-dfn-for="toggle specifier" data-dfn-type="dfn" data-export id="toggle-specifier-state-names">state names</dfn>
-    <dd data-md>
-     <p>A <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list①">list</a> of state names,
-each of which are <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string⑥">strings</a>,
-assigned to the <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle②①">toggle</a> initially upon creation.</p>
-    <dt data-md><dfn class="dfn-paneled" data-dfn-for="toggle specifier" data-dfn-type="dfn" data-export id="toggle-specifier-group">group</dfn>
-    <dd data-md>
-     <p>A boolean,
-specifying the <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle②②">toggle’s</a> initial <a data-link-type="dfn" href="#toggle-group" id="ref-for-toggle-group①">group</a> boolean upon creation.</p>
-    <dt data-md><dfn class="dfn-paneled" data-dfn-for="toggle specifier" data-dfn-type="dfn" data-export id="toggle-specifier-scope">scope</dfn>
-    <dd data-md>
-     <p>A <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string⑦">string</a> (either "wide" or "narrow"),
-specifying the <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle②③">toggle’s</a> initial <a data-link-type="dfn" href="#toggle-scope" id="ref-for-toggle-scope②">scope</a> upon creation.</p>
+     <p>A non-negative integer or a <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#identifier-value" id="ref-for-identifier-value①③">&lt;custom-ident></a> specifying the <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle②①">toggle’s</a> initial <a data-link-type="dfn" href="#toggle-state" id="ref-for-toggle-state⑥">state</a> upon creation.</p>
     <dt data-md><dfn class="dfn-paneled" data-dfn-for="toggle specifier" data-dfn-type="dfn" data-export id="toggle-specifier-maximum-state">maximum state</dfn>
     <dd data-md>
      <p>A positive integer
-specifying the highest <a data-link-type="dfn" href="#toggle-active-state" id="ref-for-toggle-active-state①">active state</a> the <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle②④">toggle</a> can reach.</p>
-    <dt data-md><dfn class="dfn-paneled" data-dfn-for="toggle specifier" data-dfn-type="dfn" data-export id="toggle-specifier-sticky">sticky</dfn>
+specifying the highest <a data-link-type="dfn" href="#toggle-active-state" id="ref-for-toggle-active-state①">active state</a> the <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle②②">toggle</a> can reach
+throught default transitions.</p>
+    <dt data-md><dfn class="dfn-paneled" data-dfn-for="toggle specifier" data-dfn-type="dfn" data-export id="toggle-specifier-state-names">state names</dfn>
     <dd data-md>
-     <p>A <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#boolean" id="ref-for-boolean①">boolean</a> specifying how to react
-when a <a data-link-type="dfn" href="#css-toggle-activation" id="ref-for-css-toggle-activation①">toggle activation</a> would push the <a data-link-type="dfn" href="#toggle-state" id="ref-for-toggle-state①">state</a> past the specified <a data-link-type="dfn" href="#toggle-specifier-maximum-state" id="ref-for-toggle-specifier-maximum-state">maximum state</a>:
-the state either stays within the <a data-link-type="dfn" href="#toggle-active-state" id="ref-for-toggle-active-state②">active states</a> and returns to 1 (if true)
-or cycles back to the <a data-link-type="dfn" href="#toggle-inactive-state" id="ref-for-toggle-inactive-state">inactive state</a> (if false).</p>
+     <p>A <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list①">list</a> of state names,
+each of which are <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#identifier-value" id="ref-for-identifier-value①④">&lt;custom-ident></a>s,
+assigned to the <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle②③">toggle</a> initially upon creation.</p>
+    <dt data-md><dfn class="dfn-paneled" data-dfn-for="toggle specifier" data-dfn-type="dfn" data-export id="toggle-specifier-group">group</dfn>
+    <dd data-md>
+     <p>A boolean,
+specifying the <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle②④">toggle’s</a> initial <a data-link-type="dfn" href="#toggle-group" id="ref-for-toggle-group①">group</a> boolean upon creation.</p>
+    <dt data-md><dfn class="dfn-paneled" data-dfn-for="toggle specifier" data-dfn-type="dfn" data-export id="toggle-specifier-scope">scope</dfn>
+    <dd data-md>
+     <p>An enum (either "wide" or "narrow"),
+specifying the <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle②⑤">toggle’s</a> initial <a data-link-type="dfn" href="#toggle-scope" id="ref-for-toggle-scope②">scope</a> upon creation.</p>
+    <dt data-md><dfn class="dfn-paneled" data-dfn-for="toggle specifier" data-dfn-type="dfn" data-export id="toggle-specifier-overflow">overflow</dfn>
+    <dd data-md>
+     <p>An enum (either "cycle" or "cycle-on" or "sticky"),
+specifying how to react when a <a data-link-type="dfn" href="#css-toggle-activation" id="ref-for-css-toggle-activation①">toggle activation</a> would increment the <a data-link-type="dfn" href="#toggle-state" id="ref-for-toggle-state⑦">state</a> above the specified <a data-link-type="dfn" href="#toggle-specifier-maximum-state" id="ref-for-toggle-specifier-maximum-state">maximum state</a>,
+or decrement the state below the (overflow-defined) minimum:</p>
+     <ul>
+      <li data-md>
+       <p>For "cycle-on",
+incrementing beyond the <a data-link-type="dfn" href="#toggle-specifier-maximum-state" id="ref-for-toggle-specifier-maximum-state①">maximum state</a> returns the toggle to the first active state (1),
+and decrementing below 1 returns the toggle to the <span id="ref-for-toggle-specifier-maximum-state②">maximum state</span>.</p>
+      <li data-md>
+       <p>For "cycle",
+incrementing beyond the <a data-link-type="dfn" href="#toggle-specifier-maximum-state" id="ref-for-toggle-specifier-maximum-state③">maximum state</a> returns the toggle to the inactive state (0),
+and decrementing below 0 returns the toggle to the <span id="ref-for-toggle-specifier-maximum-state④">maximum state</span>.</p>
+      <li data-md>
+       <p>For "sticky",
+incrementing beyond the <a data-link-type="dfn" href="#toggle-specifier-maximum-state" id="ref-for-toggle-specifier-maximum-state⑤">maximum state</a> or decrementing below 0
+does not change the toggle state.</p>
+      <li data-md>
+       <p>If the <a data-link-type="dfn" href="#toggle-state" id="ref-for-toggle-state⑧">state</a> before activation is an <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#integer-value" id="ref-for-integer-value⑦">&lt;integer></a> that is higher than the <a data-link-type="dfn" href="#toggle-specifier-maximum-state" id="ref-for-toggle-specifier-maximum-state⑥">maximum state</a>,
+or a <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#identifier-value" id="ref-for-identifier-value①⑤">&lt;custom-ident></a> that is not in the list of <a data-link-type="dfn" href="#toggle-specifier-state-names" id="ref-for-toggle-specifier-state-names">state names</a>,
+then both incrementing and decrementing follow the specified.</p>
+     </ul>
    </dl>
-   <p><a data-link-type="dfn" href="#toggle-toggle-specifier" id="ref-for-toggle-toggle-specifier">Toggle specifiers</a> are created by the <a class="property css" data-link-type="property" href="#propdef-toggle-root" id="ref-for-propdef-toggle-root①">toggle-root</a> property;
+   <p><a data-link-type="dfn" href="#toggle-toggle-specifier" id="ref-for-toggle-toggle-specifier">Toggle specifiers</a> are created by the <a class="property" data-link-type="propdesc" href="#propdef-toggle-root" id="ref-for-propdef-toggle-root①">toggle-root</a> property;
 	they are not persistent state on an element.
 	An element can have any number of <span id="ref-for-toggle-toggle-specifier①">toggle specifiers</span>.</p>
    <div class="algorithm" data-algorithm="default toggle specifier">
      A <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="default-toggle-specifier">default toggle specifier</dfn> for a given <var>name</var> is a <a data-link-type="dfn" href="#toggle-toggle-specifier" id="ref-for-toggle-toggle-specifier②">toggle specifier</a> with a <a data-link-type="dfn" href="#toggle-specifier-name" id="ref-for-toggle-specifier-name">name</a> of <var>name</var>,
 		an <a data-link-type="dfn" href="#toggle-specifier-initial-state" id="ref-for-toggle-specifier-initial-state">initial state</a> of 0,
-		a <a data-link-type="dfn" href="#toggle-specifier-state-names" id="ref-for-toggle-specifier-state-names">state names</a> of an empty <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list②">list</a>,
+		a <a data-link-type="dfn" href="#toggle-specifier-state-names" id="ref-for-toggle-specifier-state-names①">state names</a> of an empty <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list②">list</a>,
 		a false <a data-link-type="dfn" href="#toggle-specifier-group" id="ref-for-toggle-specifier-group">group</a>,
 		a <a data-link-type="dfn" href="#toggle-specifier-scope" id="ref-for-toggle-specifier-scope">scope</a> of "wide",
-		a <a data-link-type="dfn" href="#toggle-specifier-maximum-state" id="ref-for-toggle-specifier-maximum-state①">maximum state</a> of 1,
-		and a false <a data-link-type="dfn" href="#toggle-specifier-sticky" id="ref-for-toggle-specifier-sticky">sticky</a>. 
+		a <a data-link-type="dfn" href="#toggle-specifier-maximum-state" id="ref-for-toggle-specifier-maximum-state⑦">maximum state</a> of 1,
+		and a <a data-link-type="dfn" href="#toggle-specifier-overflow" id="ref-for-toggle-specifier-overflow">overflow</a> of "cycle". 
     <p class="note" role="note"><span>Note:</span> This produces behavior similar to a checkbox.</p>
    </div>
    <h3 class="heading settled" data-level="2.1" id="toggle-vs-props"><span class="secno">2.1. </span><span class="content"> Toggles and CSS Properties</span><a class="self-link" href="#toggle-vs-props"></a></h3>
    <p>To allow for toggles to be responded to by Selectors
-	without causing any circularity issues, <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle②⑤">toggles</a> themselves are invisible state on an element,
+	without causing any circularity issues, <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle②⑥">toggles</a> themselves are invisible state on an element,
 	separate from any CSS properties that might apply.
 	The CSS properties merely define which elements can <em>activate</em> a toggle,
 	and which elements can <em>respond</em> to a toggle activation
 	(and how they do so).</p>
    <div class="example" id="example-091f5f44">
-    <a class="self-link" href="#example-091f5f44"></a> For example, while an element needs <a class="property css" data-link-type="property" href="#propdef-toggle-root" id="ref-for-propdef-toggle-root②">toggle-root</a> to establish a toggle,
+    <a class="self-link" href="#example-091f5f44"></a> For example, while an element needs <a class="property" data-link-type="propdesc" href="#propdef-toggle-root" id="ref-for-propdef-toggle-root②">toggle-root</a> to establish a toggle,
 		once a toggle is created,
 		removing the <span class="property" id="ref-for-propdef-toggle-root③">toggle-root</span> property does not affect the toggle. 
 <pre class="lang-css highlight">.toggleable <c- p>{</c->
@@ -915,8 +949,8 @@ or cycles back to the <a data-link-type="dfn" href="#toggle-inactive-state" id="
 		and activate it.
 		During a rendering update,
 		the <span class="css">foo</span> toggle is created on the element
-		(initially with a value of 0, its <a data-link-type="dfn" href="#toggle-inactive-state" id="ref-for-toggle-inactive-state①">inactive state</a>);
-		when the element is clicked, it’s incremented to its <a data-link-type="dfn" href="#toggle-active-state" id="ref-for-toggle-active-state③">active state</a> (1).</p>
+		(initially with a value of 0, its <a data-link-type="dfn" href="#toggle-inactive-state" id="ref-for-toggle-inactive-state">inactive state</a>);
+		when the element is clicked, it’s incremented to its <a data-link-type="dfn" href="#toggle-active-state" id="ref-for-toggle-active-state②">active state</a> (1).</p>
     <p>At this point, the <span class="css">:toggle(foo)</span> rule begins to match,
 		and removes the <span class="css">toggle-*</span> properties.
 		This does not remove the <span class="css">foo</span> toggle or affect its value, however;
@@ -924,12 +958,12 @@ or cycles back to the <a data-link-type="dfn" href="#toggle-inactive-state" id="
 		so the <a class="css" data-link-type="maybe" href="#selectordef-toggle" id="ref-for-selectordef-toggle②">:toggle()</a> pseudo-class will continue matching.
 		However, further activations of the element
 		will no longer affect the <span class="css">foo</span> toggle,
-		since <a class="property css" data-link-type="property" href="#propdef-toggle-trigger" id="ref-for-propdef-toggle-trigger①">toggle-trigger</a> was changed to <a class="css" data-link-type="maybe" href="#valdef-toggle-trigger-none" id="ref-for-valdef-toggle-trigger-none">none</a>.</p>
+		since <a class="property" data-link-type="propdesc" href="#propdef-toggle-trigger" id="ref-for-propdef-toggle-trigger①">toggle-trigger</a> was changed to <a class="css" data-link-type="maybe" href="#valdef-toggle-trigger-none" id="ref-for-valdef-toggle-trigger-none">none</a>.</p>
     <p>The <span class="css">foo</span> toggle is thus "frozen" in the activated state
 		(unless the author has other elements in the toggle’s <a data-link-type="dfn" href="#toggle-scope" id="ref-for-toggle-scope③">scope</a> that can also affect it,
 		or tweaks the value manually via JS).</p>
    </div>
-   <h2 class="heading settled" data-level="3" id="toggle-root-property"><span class="secno">3. </span><span class="content"> Creating a Toggle: the <a class="property css" data-link-type="property" href="#propdef-toggle-root" id="ref-for-propdef-toggle-root④">toggle-root</a> property</span><a class="self-link" href="#toggle-root-property"></a></h2>
+   <h2 class="heading settled" data-level="3" id="toggle-root-property"><span class="secno">3. </span><span class="content"> Creating a Toggle: the <a class="property" data-link-type="propdesc" href="#propdef-toggle-root" id="ref-for-propdef-toggle-root④">toggle-root</a> property</span><a class="self-link" href="#toggle-root-property"></a></h2>
    <table class="def propdef" data-link-for-hint="toggle-root">
     <tbody>
      <tr>
@@ -937,7 +971,7 @@ or cycles back to the <a data-link-type="dfn" href="#toggle-inactive-state" id="
       <td><dfn class="dfn-paneled css" data-dfn-type="property" data-export id="propdef-toggle-root">toggle-root</dfn>
      <tr class="value">
       <th><a href="https://www.w3.org/TR/css-values/#value-defs">Value:</a>
-      <td class="prod">none <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one" id="ref-for-comb-one①">|</a> <a class="production css" data-link-type="type" href="#typedef-toggle-specifier" id="ref-for-typedef-toggle-specifier">&lt;toggle-specifier></a><a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#mult-comma" id="ref-for-mult-comma">#</a> 
+      <td class="prod">none <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one" id="ref-for-comb-one">|</a> <a class="production css" data-link-type="type" href="#typedef-toggle-specifier" id="ref-for-typedef-toggle-specifier">&lt;toggle-specifier></a><a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#mult-comma" id="ref-for-mult-comma">#</a> 
      <tr>
       <th><a href="https://www.w3.org/TR/css-cascade/#initial-values">Initial:</a>
       <td>none 
@@ -964,21 +998,25 @@ or cycles back to the <a data-link-type="dfn" href="#toggle-inactive-state" id="
       <td>no 
    </table>
 <pre class="prod"><dfn class="dfn-paneled" data-dfn-type="type" data-export id="typedef-toggle-specifier"><a class="production" data-link-type="type" href="#typedef-toggle-specifier" id="ref-for-typedef-toggle-specifier①">&lt;toggle-specifier></a></dfn> =
-  <a class="production" data-link-type="type" href="#typedef-toggle-toggle-name" id="ref-for-typedef-toggle-toggle-name④">&lt;toggle-name></a>
+  <a class="production" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#identifier-value" id="ref-for-identifier-value①⑥">&lt;custom-ident></a>
   [
-    [ <a class="production" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#integer-value" id="ref-for-integer-value">&lt;integer [0,∞]></a> / ]<a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#mult-opt" id="ref-for-mult-opt">?</a> <a class="production" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#integer-value" id="ref-for-integer-value①">&lt;integer [1,∞]></a> <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-any" id="ref-for-comb-any">||</a>
-    sticky <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-any" id="ref-for-comb-any①">||</a>
+    <a class="production" data-link-type="type" href="#typedef-toggle-states" id="ref-for-typedef-toggle-states">&lt;toggle-states></a> [at <a class="production" data-link-type="type" href="#typedef-toggle-state" id="ref-for-typedef-toggle-state">&lt;toggle-state></a>]<a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#mult-opt" id="ref-for-mult-opt">?</a> <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-any" id="ref-for-comb-any">||</a>
+    <a class="production" data-link-type="type" href="#typedef-toggle-overflow" id="ref-for-typedef-toggle-overflow">&lt;toggle-overflow></a> <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-any" id="ref-for-comb-any①">||</a>
     group <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-any" id="ref-for-comb-any②">||</a>
     self
   ]<a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#mult-opt" id="ref-for-mult-opt①">?</a>
+<dfn class="dfn-paneled" data-dfn-type="type" data-export id="typedef-toggle-states"><a class="production" data-link-type="type" href="#typedef-toggle-states" id="ref-for-typedef-toggle-states①">&lt;toggle-states></a></dfn> = <a class="production" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#integer-value" id="ref-for-integer-value⑧">&lt;integer [1,∞]></a> <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one" id="ref-for-comb-one①">|</a> '[' <a class="production" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#identifier-value" id="ref-for-identifier-value①⑦">&lt;custom-ident></a><a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#mult-zero-plus" id="ref-for-mult-zero-plus">*</a> ']'
+<dfn class="dfn-paneled" data-dfn-type="type" data-export id="typedef-toggle-state"><a class="production" data-link-type="type" href="#typedef-toggle-state" id="ref-for-typedef-toggle-state①">&lt;toggle-state></a></dfn> = <a class="production" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#integer-value" id="ref-for-integer-value⑨">&lt;integer [0,∞]></a> <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one" id="ref-for-comb-one②">|</a> <a class="production" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#identifier-value" id="ref-for-identifier-value①⑧">&lt;custom-ident></a>
+<dfn class="dfn-paneled" data-dfn-type="type" data-export id="typedef-toggle-overflow"><a class="production" data-link-type="type" href="#typedef-toggle-overflow" id="ref-for-typedef-toggle-overflow①">&lt;toggle-overflow></a></dfn> = cycle <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one" id="ref-for-comb-one③">|</a> cycle-on <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one" id="ref-for-comb-one④">|</a> sticky
 </pre>
-   <p>The <a class="property css" data-link-type="property" href="#propdef-toggle-root" id="ref-for-propdef-toggle-root⑤">toggle-root</a> property causes <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle②⑥">toggles</a> to be created on an element,
-	and controls how the <span id="ref-for-css-toggle②⑦">toggles</span> are updated when they are activated.</p>
+   <p>The <a class="property" data-link-type="propdesc" href="#propdef-toggle-root" id="ref-for-propdef-toggle-root⑤">toggle-root</a> property causes <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle②⑦">toggles</a> to be created on an element,
+	and controls how the <span id="ref-for-css-toggle②⑧">toggles</span> are updated when they are activated.</p>
    <dl>
     <dt><dfn class="css" data-dfn-for="toggle-root" data-dfn-type="value" data-export id="valdef-toggle-root-none">none<a class="self-link" href="#valdef-toggle-root-none"></a></dfn> 
     <dd>
       The element has no <a data-link-type="dfn" href="#toggle-toggle-specifier" id="ref-for-toggle-toggle-specifier③">toggle specifiers</a>. 
-     <p>(This does not remove any <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle②⑧">toggles</a> that have already been established on the element.)</p>
+     <p>(This does not remove any <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle②⑨">toggles</a> that have already been established
+			on the element.)</p>
     <dt><dfn class="css" data-dfn-for="toggle-root" data-dfn-type="value" data-export id="valdef-toggle-root-toggle-specifier"><a class="production css" data-link-type="type" href="#typedef-toggle-specifier" id="ref-for-typedef-toggle-specifier②">&lt;toggle-specifier></a>#<a class="self-link" href="#valdef-toggle-root-toggle-specifier"></a></dfn> 
     <dd>
       The element has one or more <a data-link-type="dfn" href="#toggle-toggle-specifier" id="ref-for-toggle-toggle-specifier④">toggle specifiers</a>,
@@ -990,22 +1028,23 @@ or cycles back to the <a data-link-type="dfn" href="#toggle-inactive-state" id="
 			corresponding to the <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#struct-item" id="ref-for-struct-item③">items</a> of a <a data-link-type="dfn" href="#toggle-toggle-specifier" id="ref-for-toggle-toggle-specifier⑤">toggle specifier</a>:</p>
      <ul>
       <li data-md>
-       <p>The initial <a class="production css" data-link-type="type" href="#typedef-toggle-toggle-name" id="ref-for-typedef-toggle-toggle-name⑤">&lt;toggle-name></a> specifies the <a data-link-type="dfn" href="#toggle-specifier-name" id="ref-for-toggle-specifier-name①">name</a>,
+       <p>The initial <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#identifier-value" id="ref-for-identifier-value①⑨">&lt;custom-ident></a> specifies the <a data-link-type="dfn" href="#toggle-specifier-name" id="ref-for-toggle-specifier-name①">name</a>,
 as the item’s value.</p>
       <li data-md>
-       <p>The first <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#integer-value" id="ref-for-integer-value②">&lt;integer></a>, if specified,
+       <p>The <a class="production css" data-link-type="type" href="#typedef-toggle-states" id="ref-for-typedef-toggle-states②">&lt;toggle-states></a>, if specified as an <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#integer-value" id="ref-for-integer-value①⓪">&lt;integer></a>,
+specifies the <a data-link-type="dfn" href="#toggle-specifier-maximum-state" id="ref-for-toggle-specifier-maximum-state⑧">maximum state</a>.
+If specified as a bracketed list of <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#identifier-value" id="ref-for-identifier-value②⓪">&lt;custom-ident></a>s,
+specifies the <a data-link-type="dfn" href="#toggle-specifier-state-names" id="ref-for-toggle-specifier-state-names②">state names</a>,
+and sets the <span id="ref-for-toggle-specifier-maximum-state⑨">maximum state</span> to the (zero-indexed) length of the list.
+If omitted, the <span id="ref-for-toggle-specifier-maximum-state①⓪">maximum state</span> is set to 1.</p>
+      <li data-md>
+       <p>The <a class="production css" data-link-type="type" href="#typedef-toggle-state" id="ref-for-typedef-toggle-state②">&lt;toggle-state></a>, if specified,
 specifies the <a data-link-type="dfn" href="#toggle-specifier-initial-state" id="ref-for-toggle-specifier-initial-state①">initial state</a>.
 If omitted, it’s set to 0.</p>
-       <p>It must be less than or equal to the second <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#integer-value" id="ref-for-integer-value③">&lt;integer></a>,
-or else the declaration is invalid.</p>
       <li data-md>
-       <p>The second <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#integer-value" id="ref-for-integer-value④">&lt;integer></a>, if specified,
-specifies the <a data-link-type="dfn" href="#toggle-specifier-maximum-state" id="ref-for-toggle-specifier-maximum-state②">maximum state</a>.
-If omitted, it’s set to 1.</p>
-      <li data-md>
-       <p>The <dfn class="dfn-paneled css" data-dfn-for="toggle-root" data-dfn-type="value" data-export id="valdef-toggle-root-sticky">sticky</dfn> keyword, if specified,
-sets the <a data-link-type="dfn" href="#toggle-specifier-sticky" id="ref-for-toggle-specifier-sticky①">sticky</a> boolean to true.
-If omitted, it’s set to false.</p>
+       <p>The <a class="production css" data-link-type="type" href="#typedef-toggle-overflow" id="ref-for-typedef-toggle-overflow②">&lt;toggle-overflow></a> keyword, if specified,
+specifies the <a data-link-type="dfn" href="#toggle-specifier-overflow" id="ref-for-toggle-specifier-overflow①">overflow</a> enum.
+If omitted, it’s set to "cycle".</p>
       <li data-md>
        <p>The <dfn class="css" data-dfn-for="toggle-root" data-dfn-type="value" data-export id="valdef-toggle-root-group">group<a class="self-link" href="#valdef-toggle-root-group"></a></dfn> keyword, if specified,
 sets the <a data-link-type="dfn" href="#toggle-specifier-group" id="ref-for-toggle-specifier-group①">group</a> boolean to true.
@@ -1016,8 +1055,8 @@ sets the <a data-link-type="dfn" href="#toggle-specifier-scope" id="ref-for-togg
 If omitted, it’s set to "wide".</p>
      </ul>
    </dl>
-   <div class="example" id="example-8d9f5102">
-    <a class="self-link" href="#example-8d9f5102"></a> Revisiting the example in the Introduction,
+   <div class="example" id="example-81cdf9d9">
+    <a class="self-link" href="#example-81cdf9d9"></a> Revisiting the example in the Introduction,
 		the same ingredient list can be specified in simple HTML and CSS: 
 <pre class="lang-html highlight"><c- p>&lt;</c-><c- f>ul</c-> <c- e>class</c-><c- o>=</c-><c- s>'ingredients'</c-><c- p>></c->
    <c- p>&lt;</c-><c- f>li</c-><c- p>></c->1 banana
@@ -1026,7 +1065,7 @@ If omitted, it’s set to "wide".</p>
 <c- p>&lt;/</c-><c- f>ul</c-><c- p>></c->
 <c- p>&lt;</c-><c- f>style</c-><c- p>></c->
 <c- f>li</c-> <c- p>{</c->
-  <c- n>toggle-root</c-><c- p>:</c-> <c- n>check</c-> <c- n>self</c-><c- p>;</c->
+  <c- n>toggle</c-><c- p>:</c-> <c- n>check</c-> <c- n>self</c-><c- p>;</c->
 <c- p>}</c->
 <c- f>li</c-><c- p>:</c-><c- nd>toggle</c-><c- o>(</c-><c- f>check</c-><c- o>)</c-> <c- p>{</c->
   <c- k>color</c-><c- p>:</c-> <c- kc>silver</c-><c- p>;</c->
@@ -1037,12 +1076,14 @@ If omitted, it’s set to "wide".</p>
     <p>The effect is identical to what was specified in the Introduction example,
 		except the markup is much simpler and more semantic.</p>
    </div>
-   <p class="issue" id="issue-80e16e8c"><a class="self-link" href="#issue-80e16e8c"></a> TODO create the <span class="css">toggle-states</span> property
-	that defines <a data-link-type="dfn" href="#toggle-state-names" id="ref-for-toggle-state-names">state names</a> for a <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle②⑨">toggle</a>,
-	and amend the various properties to allow them to take a <a class="production css" data-link-type="type" href="#typedef-toggle-toggle-name" id="ref-for-typedef-toggle-toggle-name⑥">&lt;toggle-name></a> instead of an <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#integer-value" id="ref-for-integer-value⑤">&lt;integer></a>.</p>
+   <h3 class="heading settled" data-level="3.1" id="toggle-creation"><span class="secno">3.1. </span><span class="content"> Toggle Creation Details</span><a class="self-link" href="#toggle-creation"></a></h3>
+   <p>Each <a data-link-type="dfn" href="https://drafts.csswg.org/css-display-3/#elements" id="ref-for-elements②">element</a> has a list of <dfn class="dfn-paneled" data-dfn-for="element" data-dfn-type="dfn" data-export id="element-established-toggles">established toggles</dfn>,
+	representing <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle③⓪">toggles</a> that are active on the element.
+	These are created automatically by the <a class="property" data-link-type="propdesc" href="#propdef-toggle-root" id="ref-for-propdef-toggle-root⑥">toggle-root</a> property,
+	and/or manually by interacting with the <code class="idl"><a data-link-type="idl" href="#dom-element-toggles" id="ref-for-dom-element-toggles">Element.toggles</a></code> map.</p>
    <p class="issue" id="issue-f7fd1228"><a class="self-link" href="#issue-f7fd1228"></a> Define the precise point in <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering" id="ref-for-update-the-rendering">update the rendering</a> when toggles are created
-	if <a class="property css" data-link-type="property" href="#propdef-toggle-root" id="ref-for-propdef-toggle-root⑥">toggle-root</a> names a toggle that doesn’t exist on the element yet.</p>
-   <h3 class="heading settled" data-level="3.1" id="toggle-group-property"><span class="secno">3.1. </span><span class="content"> Linking Toggle States: the <a class="property css" data-link-type="property" href="#propdef-toggle-group" id="ref-for-propdef-toggle-group①">toggle-group</a> property</span><a class="self-link" href="#toggle-group-property"></a></h3>
+	if <a class="property" data-link-type="propdesc" href="#propdef-toggle-root" id="ref-for-propdef-toggle-root⑦">toggle-root</a> names a toggle that doesn’t exist on the element yet.</p>
+   <h3 class="heading settled" data-level="3.2" id="toggle-group-property"><span class="secno">3.2. </span><span class="content"> Linking Toggle States: the <a class="property" data-link-type="propdesc" href="#propdef-toggle-group" id="ref-for-propdef-toggle-group①">toggle-group</a> property</span><a class="self-link" href="#toggle-group-property"></a></h3>
    <table class="def propdef" data-link-for-hint="toggle-group">
     <tbody>
      <tr>
@@ -1050,7 +1091,7 @@ If omitted, it’s set to "wide".</p>
       <td><dfn class="dfn-paneled css" data-dfn-type="property" data-export id="propdef-toggle-group">toggle-group</dfn>
      <tr class="value">
       <th><a href="https://www.w3.org/TR/css-values/#value-defs">Value:</a>
-      <td class="prod">none <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one" id="ref-for-comb-one②">|</a> [ <a class="production css" data-link-type="type" href="#typedef-toggle-toggle-name" id="ref-for-typedef-toggle-toggle-name⑦">&lt;toggle-name></a> self<a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#mult-opt" id="ref-for-mult-opt②">?</a> ]<a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#mult-comma" id="ref-for-mult-comma①">#</a> 
+      <td class="prod">none <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one" id="ref-for-comb-one⑤">|</a> [ <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#identifier-value" id="ref-for-identifier-value②①">&lt;custom-ident></a> self<a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#mult-opt" id="ref-for-mult-opt②">?</a> ]<a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#mult-comma" id="ref-for-mult-comma①">#</a> 
      <tr>
       <th><a href="https://www.w3.org/TR/css-cascade/#initial-values">Initial:</a>
       <td>none 
@@ -1076,33 +1117,33 @@ If omitted, it’s set to "wide".</p>
       <th><a href="https://www.w3.org/TR/web-animations/#animation-type">Animatable:</a>
       <td>no 
    </table>
-   <p>By default, each <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle③⓪">toggle’s</a> <a data-link-type="dfn" href="#toggle-state" id="ref-for-toggle-state②">state</a> is independent;
+   <p>By default, each <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle③①">toggle’s</a> <a data-link-type="dfn" href="#toggle-state" id="ref-for-toggle-state⑨">state</a> is independent;
 	incrementing one has no effect an any other.
-	The <a class="property css" data-link-type="property" href="#propdef-toggle-group" id="ref-for-propdef-toggle-group②">toggle-group</a> property allows elements to link their <span id="ref-for-css-toggle③①">toggles</span> together:
-	all <span id="ref-for-css-toggle③②">toggles</span> with the same <a data-link-type="dfn" href="#toggle-name" id="ref-for-toggle-name⑨">name</a> as the <a data-link-type="dfn" href="#css-toggle-group" id="ref-for-css-toggle-group①④">toggle group</a> that are on elements <a data-link-type="dfn" href="#toggle-in-scope" id="ref-for-toggle-in-scope②">in scope</a> for the <span id="ref-for-css-toggle-group①⑤">toggle group</span> are linked,
-	such that only one can be in an <a data-link-type="dfn" href="#toggle-active-state" id="ref-for-toggle-active-state④">active state</a> at a time,
+	The <a class="property" data-link-type="propdesc" href="#propdef-toggle-group" id="ref-for-propdef-toggle-group②">toggle-group</a> property allows elements to link their <span id="ref-for-css-toggle③②">toggles</span> together:
+	all <span id="ref-for-css-toggle③③">toggles</span> with the same <a data-link-type="dfn" href="#toggle-name" id="ref-for-toggle-name⑥">name</a> as the <a data-link-type="dfn" href="#css-toggle-group" id="ref-for-css-toggle-group①④">toggle group</a> that are on elements <a data-link-type="dfn" href="#toggle-in-scope" id="ref-for-toggle-in-scope②">in scope</a> for the <span id="ref-for-css-toggle-group①⑤">toggle group</span> are linked,
+	such that only one can be in an <a data-link-type="dfn" href="#toggle-active-state" id="ref-for-toggle-active-state③">active state</a> at a time,
 	similar to HTML’s <code>&lt;input type=radio></code> element.</p>
    <dl>
     <dt><dfn class="css" data-dfn-for="toggle-group" data-dfn-type="value" data-export id="valdef-toggle-group-none">none<a class="self-link" href="#valdef-toggle-group-none"></a></dfn> 
     <dd> The element does not define a <a data-link-type="dfn" href="#css-toggle-group" id="ref-for-css-toggle-group①⑥">toggle group</a>. 
-    <dt><dfn class="dfn-paneled css" data-dfn-for="toggle-group" data-dfn-type="value" data-export data-lt="<toggle-name> | self" id="valdef-toggle-group-toggle-name">[<a class="production css" data-link-type="type" href="#typedef-toggle-toggle-name" id="ref-for-typedef-toggle-toggle-name⑧">&lt;toggle-name></a> self?]#</dfn> 
+    <dt><dfn class="dfn-paneled css" data-dfn-for="toggle-group" data-dfn-type="value" data-export data-lt="<custom-ident> | self" id="valdef-toggle-group-custom-ident">[<a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#identifier-value" id="ref-for-identifier-value②②">&lt;custom-ident></a> self?]#</dfn> 
     <dd>
       The element defines one or more <a data-link-type="dfn" href="#css-toggle-group" id="ref-for-css-toggle-group①⑦">toggle groups</a>,
 			one per comma-separated item: 
      <ul>
       <li data-md>
-       <p>The <a class="production css" data-link-type="type" href="#typedef-toggle-toggle-name" id="ref-for-typedef-toggle-toggle-name⑨">&lt;toggle-name></a> specifies the <a data-link-type="dfn" href="#toggle-group-name" id="ref-for-toggle-group-name">name</a>,
+       <p>The <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#identifier-value" id="ref-for-identifier-value②③">&lt;custom-ident></a> specifies the <a data-link-type="dfn" href="#toggle-group-name" id="ref-for-toggle-group-name">name</a>,
 as the item’s value.</p>
       <li data-md>
-       <p>The <a class="css" data-link-type="maybe" href="#valdef-toggle-group-toggle-name" id="ref-for-valdef-toggle-group-toggle-name">self</a> keyword, if specified,
+       <p>The <a class="css" data-link-type="maybe" href="#valdef-toggle-group-custom-ident" id="ref-for-valdef-toggle-group-custom-ident">self</a> keyword, if specified,
 sets the <a data-link-type="dfn" href="#toggle-group-scope" id="ref-for-toggle-group-scope">scope</a> enum to "narrow".
 If omitted, it’s set to "wide".</p>
      </ul>
-     <p>Only one <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle③③">toggle</a> <a data-link-type="dfn" href="#toggle-in-a-toggle-group" id="ref-for-toggle-in-a-toggle-group">in a toggle group</a> can be in an <a data-link-type="dfn" href="#toggle-active-state" id="ref-for-toggle-active-state⑤">active state</a> at a time;
-			see <a class="property css" data-link-type="property" href="#propdef-toggle-trigger" id="ref-for-propdef-toggle-trigger②">toggle-trigger</a> for details.</p>
+     <p>Only one <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle③④">toggle</a> <a data-link-type="dfn" href="#toggle-in-a-toggle-group" id="ref-for-toggle-in-a-toggle-group">in a toggle group</a> can be in an <a data-link-type="dfn" href="#toggle-active-state" id="ref-for-toggle-active-state④">active state</a> at a time;
+			see <a class="property" data-link-type="propdesc" href="#propdef-toggle-trigger" id="ref-for-propdef-toggle-trigger②">toggle-trigger</a> for details.</p>
    </dl>
-   <div class="example" id="example-1171420a">
-    <a class="self-link" href="#example-1171420a"></a> For example, <a class="property css" data-link-type="property" href="#propdef-toggle-group" id="ref-for-propdef-toggle-group③">toggle-group</a> can be used to control a tabbed display,
+   <div class="example" id="example-b7451059">
+    <a class="self-link" href="#example-b7451059"></a> For example, <a class="property" data-link-type="propdesc" href="#propdef-toggle-group" id="ref-for-propdef-toggle-group③">toggle-group</a> can be used to control a tabbed display,
 		so that only one panel is displayed at a time: 
 <pre class="lang-html highlight"><c- p>&lt;</c-><c- f>panel-set</c-><c- p>></c->
   <c- p>&lt;</c-><c- f>panel-tab</c-><c- p>></c->first tab<c- p>&lt;/</c-><c- f>panel-tab</c-><c- p>></c->
@@ -1117,16 +1158,16 @@ If omitted, it’s set to "wide".</p>
   <c- n>toggle-group</c-><c- p>:</c-> <c- n>tab</c-><c- p>;</c->
 <c- p>}</c->
 <c- f>panel-tab</c-> <c- p>{</c->
-  <c- c>/* Each tab creates a sticky toggle</c->
+  <c- c>/* Each tab creates a cycle-on toggle</c->
 <c- c>    (so once it’s open, clicking again won’t close it),</c->
 <c- c>    opts into the group,</c->
 <c- c>    and declares itself a toggle activator */</c->
-  <c- n>toggle</c-><c- p>:</c-> <c- n>tab</c-> <c- mi>1</c-> <c- n>group</c-> <c- kc>sticky</c-><c- p>;</c->
+  <c- n>toggle</c-><c- p>:</c-> <c- n>tab</c-> <c- mi>1</c-> <c- n>group</c-> <c- n>cycle-on</c-><c- p>;</c->
 <c- p>}</c->
 <c- f>panel-tab</c-><c- p>:</c-><c- nd>first-of-type</c-> <c- p>{</c->
   <c- c>/* The first tab also sets its initial state</c->
 <c- c>    to be active */</c->
-  <c- n>toggle</c-><c- p>:</c-> <c- n>tab</c-> <c- mi>1</c-><c- o>/</c-><c- mi>1</c-> <c- n>group</c-> <c- kc>sticky</c-><c- p>;</c->
+  <c- n>toggle</c-><c- p>:</c-> <c- n>tab</c-> <c- mi>1</c-> <c- n>at</c-> <c- mi>1</c-> <c- n>group</c-> <c- n>cycle-on</c-><c- p>;</c->
 <c- p>}</c->
 <c- f>panel-tab</c-><c- p>:</c-><c- nd>toggle</c-><c- o>(</c-><c- f>tab</c-><c- o>)</c-> <c- p>{</c->
   <c- c>/* styling for the active tab */</c->
@@ -1140,11 +1181,11 @@ If omitted, it’s set to "wide".</p>
 <c- p>}</c->
 <c- p>&lt;/</c-><c- f>style</c-><c- p>></c->
 </pre>
-    <p>Clicking on any tab will increment its corresponding <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle③④">toggle’s</a> <a data-link-type="dfn" href="#toggle-state" id="ref-for-toggle-state③">state</a> from 0 to 1
-		(and the <a class="css" data-link-type="maybe" href="#valdef-toggle-root-sticky" id="ref-for-valdef-toggle-root-sticky">sticky</a> keyword will keep it at 1 if activated multiple times),
-		while resetting the rest of the tabs' <span id="ref-for-toggle-state④">states</span> to 0.
-		Each panel is <a data-link-type="dfn" href="#toggle-in-scope" id="ref-for-toggle-in-scope③">in scope</a> for the <span id="ref-for-css-toggle③⑤">toggle</span> defined by its preceding tab,
-		so it can respond to the <span id="ref-for-toggle-state⑤">state</span> as well.</p>
+    <p>Clicking on any tab will increment its corresponding <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle③⑤">toggle’s</a> <a data-link-type="dfn" href="#toggle-state" id="ref-for-toggle-state①⓪">state</a> from 0 to 1
+		(and the <span class="css">cycle-on</span> keyword will keep it at 1 if activated multiple times),
+		while resetting the rest of the tabs' <span id="ref-for-toggle-state①①">states</span> to 0.
+		Each panel is <a data-link-type="dfn" href="#toggle-in-scope" id="ref-for-toggle-in-scope③">in scope</a> for the <span id="ref-for-css-toggle③⑥">toggle</span> defined by its preceding tab,
+		so it can respond to the <span id="ref-for-toggle-state①②">state</span> as well.</p>
    </div>
    <div class="issue" id="issue-47da3fb8">
     <a class="self-link" href="#issue-47da3fb8"></a> Radio buttons have one particular tabbing/switching/activation behavior
@@ -1158,7 +1199,7 @@ If omitted, it’s set to "wide".</p>
     <p>We probably want to add a bool to toggle groups dictating this;
 		are there more than these two behaviors to deal with?</p>
    </div>
-   <h3 class="heading settled" data-level="3.2" id="toggle-trigger-property"><span class="secno">3.2. </span><span class="content"> Activating a Toggle: the <a class="property css" data-link-type="property" href="#propdef-toggle-trigger" id="ref-for-propdef-toggle-trigger③">toggle-trigger</a> property</span><a class="self-link" href="#toggle-trigger-property"></a></h3>
+   <h3 class="heading settled" data-level="3.3" id="toggle-trigger-property"><span class="secno">3.3. </span><span class="content"> Activating a Toggle: the <a class="property" data-link-type="propdesc" href="#propdef-toggle-trigger" id="ref-for-propdef-toggle-trigger③">toggle-trigger</a> property</span><a class="self-link" href="#toggle-trigger-property"></a></h3>
    <table class="def propdef" data-link-for-hint="toggle-trigger">
     <tbody>
      <tr>
@@ -1166,7 +1207,7 @@ If omitted, it’s set to "wide".</p>
       <td><dfn class="dfn-paneled css" data-dfn-type="property" data-export id="propdef-toggle-trigger">toggle-trigger</dfn>
      <tr class="value">
       <th><a href="https://www.w3.org/TR/css-values/#value-defs">Value:</a>
-      <td class="prod">none <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one" id="ref-for-comb-one③">|</a> [ <a class="production css" data-link-type="type" href="#typedef-toggle-toggle-name" id="ref-for-typedef-toggle-toggle-name①⓪">&lt;toggle-name></a> <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#integer-value" id="ref-for-integer-value⑥">&lt;integer [0,∞]></a><a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#mult-opt" id="ref-for-mult-opt③">?</a> ]<a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#mult-comma" id="ref-for-mult-comma②">#</a> 
+      <td class="prod">none <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one" id="ref-for-comb-one⑥">|</a> <a class="production css" data-link-type="type">&lt;toggle-trigger></a><a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#mult-comma" id="ref-for-mult-comma②">#</a> 
      <tr>
       <th><a href="https://www.w3.org/TR/css-cascade/#initial-values">Initial:</a>
       <td>none 
@@ -1192,33 +1233,47 @@ If omitted, it’s set to "wide".</p>
       <th><a href="https://www.w3.org/TR/web-animations/#animation-type">Animatable:</a>
       <td>no 
    </table>
-   <p>The <a class="property css" data-link-type="property" href="#propdef-toggle-trigger" id="ref-for-propdef-toggle-trigger④">toggle-trigger</a> property specifies that an element can be activated
-	to change the state of one or more <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle③⑥">toggles</a>.
+<pre class="prod"><df><a class="production" data-link-type="type">&lt;toggle-trigger></a> = <a class="production" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#identifier-value" id="ref-for-identifier-value②④">&lt;custom-ident></a> <a class="production" data-link-type="type" href="#typedef-trigger-action" id="ref-for-typedef-trigger-action">&lt;trigger-action></a><a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#mult-opt" id="ref-for-mult-opt③">?</a>
+<dfn class="dfn-paneled" data-dfn-type="type" data-export id="typedef-trigger-action"><a class="production" data-link-type="type" href="#typedef-trigger-action" id="ref-for-typedef-trigger-action①">&lt;trigger-action></a></dfn> =
+  prev <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one" id="ref-for-comb-one⑦">|</a> next <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one" id="ref-for-comb-one⑧">|</a>
+  set <a class="production" data-link-type="type" href="#typedef-toggle-state" id="ref-for-typedef-toggle-state③">&lt;toggle-state></a>
+</df></pre>
+   <p>The <a class="property" data-link-type="propdesc" href="#propdef-toggle-trigger" id="ref-for-propdef-toggle-trigger④">toggle-trigger</a> property specifies that an element can be activated
+	to change the state of one or more <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle③⑦">toggles</a>.
 	It has the following values:</p>
+   <p class="issue" id="issue-b8bd39f2"><a class="self-link" href="#issue-b8bd39f2"></a> Consider adding support for an at-rule that defines machine states,
+	the available events to trigger from each state,
+	and the resulting state of each event.
+	In that case <a class="production css" data-link-type="type" href="#typedef-trigger-action" id="ref-for-typedef-trigger-action②">&lt;trigger-action></a> would need to also accept custom events,
+	possibly marked by a new keyword or function.</p>
    <dl>
     <dt data-md><dfn class="dfn-paneled css" data-dfn-for="toggle-trigger" data-dfn-type="value" data-export id="valdef-toggle-trigger-none">none</dfn>
     <dd data-md>
-     <p>The element does not manipulated any <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle③⑦">toggles</a>.</p>
-    <dt data-md><dfn class="css" data-dfn-for="toggle-trigger" data-dfn-type="value" data-export id="valdef-toggle-trigger-toggle-name-integer-0"><a class="production css" data-link-type="type" href="#typedef-toggle-toggle-name" id="ref-for-typedef-toggle-toggle-name①①">&lt;toggle-name></a> <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#integer-value" id="ref-for-integer-value⑦">&lt;integer [0,∞]></a>?<a class="self-link" href="#valdef-toggle-trigger-toggle-name-integer-0"></a></dfn>
+     <p>The element does not manipulate any <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle③⑧">toggles</a>.</p>
+    <dt data-md><a class="production css" data-link-type="type">&lt;toggle-trigger></a>
     <dd data-md>
      <p>If the element already has existing activation behavior from the host language,
 this value does nothing.</p>
      <p>Otherwise, the element becomes activatable,
 and when activated,
-for each comma-separated entry in the list, <a data-link-type="dfn" href="#fire-a-toggle-activation" id="ref-for-fire-a-toggle-activation">fires</a> a <a data-link-type="dfn" href="#css-toggle-activation" id="ref-for-css-toggle-activation②">toggle activation</a> with the given <a class="production css" data-link-type="type" href="#typedef-toggle-toggle-name" id="ref-for-typedef-toggle-toggle-name①②">&lt;toggle-name></a> and, if an <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#integer-value" id="ref-for-integer-value⑧">&lt;integer></a> is specified,
-a target state of that integer.</p>
+for each comma-separated entry in the list, <a data-link-type="dfn" href="#fire-a-toggle-activation" id="ref-for-fire-a-toggle-activation">fires</a> a <a data-link-type="dfn" href="#css-toggle-activation" id="ref-for-css-toggle-activation②">toggle activation</a> with the given <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#identifier-value" id="ref-for-identifier-value②⑤">&lt;custom-ident></a> as a <a data-link-type="dfn" href="#toggle-activation-name" id="ref-for-toggle-activation-name">name</a>,
+and the <a class="production css" data-link-type="type" href="#typedef-trigger-action" id="ref-for-typedef-trigger-action③">&lt;trigger-action></a> <a data-link-type="dfn">event</a>, if specified.</p>
    </dl>
    <p>A <dfn class="dfn-paneled" data-dfn-for="CSS" data-dfn-type="dfn" data-export id="css-toggle-activation">toggle activation</dfn> is a struct with the following items:</p>
    <dl>
     <dt data-md><dfn class="dfn-paneled" data-dfn-for="toggle activation" data-dfn-type="dfn" data-export id="toggle-activation-name">name</dfn>
     <dd data-md>
-     <p>The <a data-link-type="dfn" href="#toggle-name" id="ref-for-toggle-name①⓪">name</a> of the <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle③⑧">toggle</a> this is intended activate.</p>
-    <dt data-md><dfn class="dfn-paneled" data-dfn-for="toggle activation" data-dfn-type="dfn" data-export id="toggle-activation-target-state">target state</dfn>
+     <p>The <a data-link-type="dfn" href="#toggle-name" id="ref-for-toggle-name⑦">name</a> of the <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle③⑨">toggle</a> this is intended to activate.</p>
+    <dt data-md><dfn class="dfn-paneled" data-dfn-for="toggle activation" data-dfn-type="dfn" data-export id="toggle-activation-event">event</dfn>
     <dd data-md>
-     <p>An optional non-negative integer.</p>
-     <p>If specified, gives the <a data-link-type="dfn" href="#toggle-state" id="ref-for-toggle-state⑥">state</a> that this activation will attempt to put the <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle③⑨">toggle</a> into.
-If unspecified,
-indicates that this activation will increment the <span id="ref-for-css-toggle④⓪">toggle’s</span> current <span id="ref-for-toggle-state⑦">state</span>.</p>
+     <p>If unspecified, or specified as the keyword <a class="property" data-link-type="propdesc">next</a>,
+indicates that this activation will increment
+the <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle④⓪">toggle’s</a> current <a data-link-type="dfn" href="#toggle-state" id="ref-for-toggle-state①③">state</a>.
+If specified as the keyword <span class="property">prev</span>,
+indicates that this activation will decrement
+the <span id="ref-for-css-toggle④①">toggle’s</span> current <span id="ref-for-toggle-state①④">state</span>.
+If specified with the keyword <span class="property">set</span> and a <a class="production css" data-link-type="type" href="#typedef-toggle-state" id="ref-for-typedef-toggle-state④">&lt;toggle-state></a>,
+indicates the exact <span id="ref-for-toggle-state①⑤">state</span> that this activation will attempt to put the <span id="ref-for-css-toggle④②">toggle</span> into.</p>
    </dl>
    <div class="algorithm" data-algorithm="fire a toggle activation">
      To <dfn class="dfn-paneled" data-dfn-type="dfn" data-export data-local-lt="fire" id="fire-a-toggle-activation">fire a toggle activation</dfn> on an element <var>initial element</var> with a <a data-link-type="dfn" href="#css-toggle-activation" id="ref-for-css-toggle-activation③">toggle activation</a> <var>activation</var>: 
@@ -1226,36 +1281,32 @@ indicates that this activation will increment the <span id="ref-for-css-toggle�
      <li data-md>
       <p>Let <var>el</var> initially be <var>initial element</var>.</p>
      <li data-md>
-      <p>If <var>el</var> has a <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle④①">toggle</a> with the same <a data-link-type="dfn" href="#toggle-name" id="ref-for-toggle-name①①">name</a> as <var>activation</var>,
-and <var>initial element</var> is <a data-link-type="dfn" href="#toggle-in-scope" id="ref-for-toggle-in-scope④">in scope</a> for the <span id="ref-for-css-toggle④②">toggle</span>,
+      <p>If <var>el</var> has a <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle④③">toggle</a> with the same <a data-link-type="dfn" href="#toggle-name" id="ref-for-toggle-name⑧">name</a> as <var>activation</var>,
+and <var>initial element</var> is <a data-link-type="dfn" href="#toggle-in-scope" id="ref-for-toggle-in-scope④">in scope</a> for the <span id="ref-for-css-toggle④④">toggle</span>,
 then:</p>
       <ol>
        <li data-md>
-        <p>Let <var>toggle</var> be the <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle④③">toggle</a>.</p>
+        <p>Let <var>toggle</var> be the <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle④⑤">toggle</a>.</p>
        <li data-md>
         <p>If <var>el</var> has a <a data-link-type="dfn" href="#toggle-toggle-specifier" id="ref-for-toggle-toggle-specifier⑥">toggle specifier</a> with the same <a data-link-type="dfn" href="#toggle-specifier-name" id="ref-for-toggle-specifier-name②">name</a>,
 let <var>specifier</var> be it.</p>
-        <p>Otherwise, let <var>specifier</var> be a new <a data-link-type="dfn" href="#default-toggle-specifier" id="ref-for-default-toggle-specifier">default toggle specifier</a> for <var>activation</var>’s <a data-link-type="dfn" href="#toggle-activation-name" id="ref-for-toggle-activation-name">name</a>.</p>
+        <p>Otherwise, let <var>specifier</var> be a new <a data-link-type="dfn" href="#default-toggle-specifier" id="ref-for-default-toggle-specifier">default toggle specifier</a> for <var>activation</var>’s <a data-link-type="dfn" href="#toggle-activation-name" id="ref-for-toggle-activation-name①">name</a>.</p>
        <li data-md>
-        <p>If <var>activation</var>’s <a data-link-type="dfn" href="#toggle-activation-target-state" id="ref-for-toggle-activation-target-state">target state</a> is specified,
-set <var>toggle</var>’s <a data-link-type="dfn" href="#toggle-state" id="ref-for-toggle-state⑧">state</a> to the smaller of the <span id="ref-for-toggle-activation-target-state①">target state</span> and <var>specifier</var>’s <a data-link-type="dfn" href="#toggle-specifier-maximum-state" id="ref-for-toggle-specifier-maximum-state③">maximum state</a>.</p>
-        <p>Otherwise,
-increment <var>toggle</var>’s <a data-link-type="dfn" href="#toggle-state" id="ref-for-toggle-state⑨">state</a> by 1.
-If the <span id="ref-for-toggle-state①⓪">state</span> is now higher than <var>specifier</var>’s <a data-link-type="dfn" href="#toggle-specifier-maximum-state" id="ref-for-toggle-specifier-maximum-state④">maximum state</a>,
-then set the <span id="ref-for-toggle-state①①">state</span> to 1
-if <var>specifier</var>’s <a data-link-type="dfn" href="#toggle-specifier-sticky" id="ref-for-toggle-specifier-sticky②">sticky</a> flag is true,
-and to 0 if it’s false.</p>
+        <p>Set <var>toggle</var>’s <a data-link-type="dfn" href="#toggle-state" id="ref-for-toggle-state①⑥">state</a> to the result of
+the specified <a data-link-type="dfn" href="#toggle-activation-event" id="ref-for-toggle-activation-event">event</a>,
+following the specified <a data-link-type="dfn" href="#toggle-specifier-overflow" id="ref-for-toggle-specifier-overflow②">overflow</a> behavior
+when incrementing or decrementing.</p>
        <li data-md>
-        <p>If <var>toggle</var>’s <a data-link-type="dfn" href="#toggle-state" id="ref-for-toggle-state①②">state</a> is now greater than zero
+        <p>If <var>toggle</var>’s <a data-link-type="dfn" href="#toggle-state" id="ref-for-toggle-state①⑦">state</a> is now greater than zero
 and <var>toggle</var> is <a data-link-type="dfn" href="#toggle-in-a-toggle-group" id="ref-for-toggle-in-a-toggle-group①">in a toggle group</a>,
-then for each <em>other</em> <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle④④">toggle</a> in the same <a data-link-type="dfn" href="#css-toggle-group" id="ref-for-css-toggle-group①⑧">toggle group</a>,
-set their <span id="ref-for-toggle-state①③">state</span> to 0.</p>
+then for each <em>other</em> <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle④⑥">toggle</a> in the same <a data-link-type="dfn" href="#css-toggle-group" id="ref-for-css-toggle-group①⑧">toggle group</a>,
+set their <span id="ref-for-toggle-state①⑧">state</span> to 0.</p>
        <li data-md>
         <p>Return from this algorithm.</p>
       </ol>
      <li data-md>
       <p>Otherwise,
-continue searching for a <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle④⑤">toggle</a>:</p>
+continue searching for a <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle④⑦">toggle</a>:</p>
       <ul>
        <li data-md>
         <p>If <var>el</var> has a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-tree-previous-sibling" id="ref-for-concept-tree-previous-sibling">previous sibling</a>,
@@ -1278,7 +1329,7 @@ and return to step 2.</p>
 	we want to exclude things like text inputs,
 	which would confuse a11y tooling,
 	but include buttons that aren’t, like, submit buttons.</p>
-   <h3 class="heading settled" data-level="3.3" id="toggle-property"><span class="secno">3.3. </span><span class="content"> Creating and Activating Toggles Simultaneously: the <a class="property css" data-link-type="property" href="#propdef-toggle" id="ref-for-propdef-toggle">toggle</a> shorthand</span><a class="self-link" href="#toggle-property"></a></h3>
+   <h3 class="heading settled" data-level="3.4" id="toggle-property"><span class="secno">3.4. </span><span class="content"> Creating and Activating Toggles Simultaneously: the <a class="property" data-link-type="propdesc" href="#propdef-toggle" id="ref-for-propdef-toggle">toggle</a> shorthand</span><a class="self-link" href="#toggle-property"></a></h3>
    <table class="def propdef" data-link-for-hint="toggle">
     <tbody>
      <tr>
@@ -1286,7 +1337,7 @@ and return to step 2.</p>
       <td><dfn class="dfn-paneled css" data-dfn-type="property" data-export id="propdef-toggle">toggle</dfn>
      <tr class="value">
       <th><a href="https://www.w3.org/TR/css-values/#value-defs">Value:</a>
-      <td class="prod"><a class="production css" data-link-type="property" href="#propdef-toggle-root" id="ref-for-propdef-toggle-root⑦">&lt;'toggle-root'></a> 
+      <td class="prod"><a class="production" data-link-type="propdesc" href="#propdef-toggle-root" id="ref-for-propdef-toggle-root⑧">&lt;'toggle-root'></a> 
      <tr>
       <th><a href="https://www.w3.org/TR/css-cascade/#initial-values">Initial:</a>
       <td>see individual properties 
@@ -1309,12 +1360,12 @@ and return to step 2.</p>
       <th><a href="https://www.w3.org/TR/cssom/#serializing-css-values">Canonical order:</a>
       <td>per grammar 
    </table>
-   <p>While some cases require setting up a <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle④⑥">toggle</a> on an ancestor
+   <p>While some cases require setting up a <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle④⑧">toggle</a> on an ancestor
 	of the elements that will activate and respond to the toggle,
-	in many cases the <a data-link-type="dfn" href="#toggle-scope" id="ref-for-toggle-scope④">scope</a> rules for <span id="ref-for-css-toggle④⑦">toggles</span> are such that it’s fine to create the <span id="ref-for-css-toggle④⑧">toggle</span> on the element intended to activate the toggle as well.</p>
-   <p>The <a class="property css" data-link-type="property" href="#propdef-toggle" id="ref-for-propdef-toggle①">toggle</a> shorthand sets both the <a class="property css" data-link-type="property" href="#propdef-toggle-root" id="ref-for-propdef-toggle-root⑧">toggle-root</a> and <a class="property css" data-link-type="property" href="#propdef-toggle-trigger" id="ref-for-propdef-toggle-trigger⑤">toggle-trigger</a> properties on an element together.
-	The entire value of the property is assigned to <span class="property" id="ref-for-propdef-toggle-root⑨">toggle-root</span>,
-	while <span class="property" id="ref-for-propdef-toggle-trigger⑥">toggle-trigger</span> is assigned to just the <a class="production css" data-link-type="type" href="#typedef-toggle-toggle-name" id="ref-for-typedef-toggle-toggle-name①③">&lt;toggle-name></a>s specified in the list,
+	in many cases the <a data-link-type="dfn" href="#toggle-scope" id="ref-for-toggle-scope④">scope</a> rules for <span id="ref-for-css-toggle④⑨">toggles</span> are such that it’s fine to create the <span id="ref-for-css-toggle⑤⓪">toggle</span> on the element intended to activate the toggle as well.</p>
+   <p>The <a class="property" data-link-type="propdesc" href="#propdef-toggle" id="ref-for-propdef-toggle①">toggle</a> shorthand sets both the <a class="property" data-link-type="propdesc" href="#propdef-toggle-root" id="ref-for-propdef-toggle-root⑨">toggle-root</a> and <a class="property" data-link-type="propdesc" href="#propdef-toggle-trigger" id="ref-for-propdef-toggle-trigger⑤">toggle-trigger</a> properties on an element together.
+	The entire value of the property is assigned to <span class="property" id="ref-for-propdef-toggle-root①⓪">toggle-root</span>,
+	while <span class="property" id="ref-for-propdef-toggle-trigger⑥">toggle-trigger</span> is assigned to just the <a class="production css" data-link-type="type">&lt;custom-idents></a>s specified in the list,
 	if any.</p>
    <div class="example" id="example-9e93d6b5">
     <a class="self-link" href="#example-9e93d6b5"></a> For example,
@@ -1335,19 +1386,19 @@ and return to step 2.</p>
 <c- p>&lt;/</c-><c- f>style</c-><c- p>></c->
 </pre>
    </div>
-   <h3 class="heading settled" data-level="3.4" id="a11y"><span class="secno">3.4. </span><span class="content"> Accessibility Implications of Toggles</span><a class="self-link" href="#a11y"></a></h3>
-   <div class="issue" id="issue-d75619e8">
-    <a class="self-link" href="#issue-d75619e8"></a> TODO 
+   <h3 class="heading settled" data-level="3.5" id="a11y"><span class="secno">3.5. </span><span class="content"> Accessibility Implications of Toggles</span><a class="self-link" href="#a11y"></a></h3>
+   <div class="issue" id="issue-55ec88b3">
+    <a class="self-link" href="#issue-55ec88b3"></a> TODO 
     <ul>
      <li data-md>
-      <p>a <a class="property css" data-link-type="property" href="#propdef-toggle-trigger" id="ref-for-propdef-toggle-trigger⑦">toggle-trigger</a> element needs to become activatable/focusable/etc,
+      <p>a <a class="property" data-link-type="propdesc" href="#propdef-toggle-trigger" id="ref-for-propdef-toggle-trigger⑦">toggle-trigger</a> element needs to become activatable/focusable/etc,
 and communicate in the a11y tree that it’s a checkbox/radio/etc</p>
      <li data-md>
       <p>we can infer what type of control it is
 by examining the properties of the toggle:
-if it’s part of a group, sticky, etc.</p>
+if it’s part of a group, cycle-on, etc.</p>
      <li data-md>
-      <p>if <a class="property css" data-link-type="property" href="#propdef-toggle-visibility" id="ref-for-propdef-toggle-visibility">toggle-visibility</a> is in use,
+      <p>if <a class="property" data-link-type="propdesc" href="#propdef-toggle-visibility" id="ref-for-propdef-toggle-visibility">toggle-visibility</a> is in use,
 we can also automatically infer all the tab-set ARIA roles</p>
     </ul>
    </div>
@@ -1356,16 +1407,17 @@ we can also automatically infer all the tab-set ARIA roles</p>
 	which allows author to match certain elements
 	(as defined by the host language)
 	depending on their "checked" state.</p>
-   <p><a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle④⑨">Toggles</a> provides a very similar functionality,
-	allowing elements to be selected based on their <span id="ref-for-css-toggle⑤⓪">toggle</span> <a data-link-type="dfn" href="#toggle-state" id="ref-for-toggle-state①④">state</a>,
+   <p><a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle⑤①">Toggles</a> provides a very similar functionality,
+	allowing elements to be selected based on their <span id="ref-for-css-toggle⑤②">toggle</span> <a data-link-type="dfn" href="#toggle-state" id="ref-for-toggle-state①⑨">state</a>,
 	the <dfn class="dfn-paneled css" data-dfn-type="selector" data-export id="selectordef-toggle">:toggle()</dfn> pseudo-class:</p>
-<pre class="prod">:toggle( <a class="production" data-link-type="type" href="#typedef-toggle-toggle-name" id="ref-for-typedef-toggle-toggle-name①④">&lt;toggle-name></a> <a class="production" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#integer-value" id="ref-for-integer-value⑨">&lt;integer></a><a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#mult-opt" id="ref-for-mult-opt④">?</a> )
+<pre class="prod">:toggle( <a class="production" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#identifier-value" id="ref-for-identifier-value②⑥">&lt;custom-ident></a> <a class="production" data-link-type="type" href="#typedef-toggle-state" id="ref-for-typedef-toggle-state⑤">&lt;toggle-state></a><a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#mult-opt" id="ref-for-mult-opt④">?</a> )
 </pre>
-   <p>An element matches <a class="css" data-link-type="maybe" href="#selectordef-toggle" id="ref-for-selectordef-toggle④">:toggle()</a> if the element is <a data-link-type="dfn" href="#toggle-in-scope" id="ref-for-toggle-in-scope⑤">in scope</a> for a <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle⑤①">toggle</a> with the <a data-link-type="dfn" href="#toggle-name" id="ref-for-toggle-name①②">name</a> given by <a class="production css" data-link-type="type" href="#typedef-toggle-toggle-name" id="ref-for-typedef-toggle-toggle-name①⑤">&lt;toggle-name></a>,
-	and either the <span id="ref-for-css-toggle⑤②">toggle’s</span> <a data-link-type="dfn" href="#toggle-state" id="ref-for-toggle-state①⑤">state</a> matches the provided <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#integer-value" id="ref-for-integer-value①⓪">&lt;integer></a>,
-	or the <span class="production" id="ref-for-integer-value①①">&lt;integer></span> is omitted and the <span id="ref-for-css-toggle⑤③">toggle</span> is in any <a data-link-type="dfn" href="#toggle-active-state" id="ref-for-toggle-active-state⑥">active state</a>.</p>
+   <p>An element matches <a class="css" data-link-type="maybe" href="#selectordef-toggle" id="ref-for-selectordef-toggle④">:toggle()</a> if the element is <a data-link-type="dfn" href="#toggle-in-scope" id="ref-for-toggle-in-scope⑤">in scope</a> for a <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle⑤③">toggle</a> with the <a data-link-type="dfn" href="#toggle-name" id="ref-for-toggle-name⑨">name</a> given by <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#identifier-value" id="ref-for-identifier-value②⑦">&lt;custom-ident></a>,
+	and either the <span id="ref-for-css-toggle⑤④">toggle’s</span> <a data-link-type="dfn" href="#toggle-state" id="ref-for-toggle-state②⓪">state</a> <a data-link-type="dfn" href="#toggle-match-state" id="ref-for-toggle-match-state">matches</a> the provided <a class="production css" data-link-type="type" href="#typedef-toggle-state" id="ref-for-typedef-toggle-state⑥">&lt;toggle-state></a>,
+	or the <span class="production" id="ref-for-typedef-toggle-state⑦">&lt;toggle-state></span> is omitted
+	and the <span id="ref-for-css-toggle⑤⑤">toggle</span> is in any <a data-link-type="dfn" href="#toggle-active-state" id="ref-for-toggle-active-state⑤">active state</a>.</p>
    <div class="example" id="example-d684b11f">
-    <a class="self-link" href="#example-d684b11f"></a> For example, if a <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle⑤④">toggle</a> named "used"
+    <a class="self-link" href="#example-d684b11f"></a> For example, if a <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle⑤⑥">toggle</a> named "used"
 		is defined on each element in an recipe’s ingredient list,
 		the ingredients can respond to being clicked on easily: 
 <pre class="lang-css highlight">.ingredient <c- p>{</c->
@@ -1377,11 +1429,11 @@ we can also automatically infer all the tab-set ARIA roles</p>
 <c- p>}</c->
 </pre>
    </div>
-   <div class="example" id="example-c621fdae">
-    <a class="self-link" href="#example-c621fdae"></a> A checkbox that can represent an "indeterminate" value
+   <div class="example" id="example-6be97bc4">
+    <a class="self-link" href="#example-6be97bc4"></a> A checkbox that can represent an "indeterminate" value
 		might have two active states. 
 <pre class="lang-css highlight">.tristate-check <c- p>{</c->
-  <c- k>toggle</c-><c- p>:</c-> check <c- m>0</c->/<c- m>2</c-><c- p>;</c->
+  <c- k>toggle</c-><c- p>:</c-> check <c- m>2</c-> at <c- m>0</c-><c- p>;</c->
 <c- p>}</c->
 .tristate-check<c- nf>:toggle</c-><c- p>(</c->check <c- m>1</c-><c- p>)</c-> <c- p>{</c->
   <c- c>/* "checked" styles */</c->
@@ -1393,19 +1445,19 @@ we can also automatically infer all the tab-set ARIA roles</p>
    </div>
    <div class="example" id="example-afd180be">
     <a class="self-link" href="#example-afd180be"></a> While <span class="css">:not(:toggle(foo))</span> will correctly match an element
-		whose "foo" toggle is in an <a data-link-type="dfn" href="#toggle-inactive-state" id="ref-for-toggle-inactive-state②">inactive state</a>,
+		whose "foo" toggle is in an <a data-link-type="dfn" href="#toggle-inactive-state" id="ref-for-toggle-inactive-state①">inactive state</a>,
 		it will <em>also</em> match any element
 		that doesn’t see a "foo" toggle at all. 
     <p>If this is inconvenient,
 		only elements that actually know about a particular toggle
-		can be targeted by specifying the <a data-link-type="dfn" href="#toggle-inactive-state" id="ref-for-toggle-inactive-state③">inactive state</a> specifically:</p>
+		can be targeted by specifying the <a data-link-type="dfn" href="#toggle-inactive-state" id="ref-for-toggle-inactive-state②">inactive state</a> specifically:</p>
 <pre class="lang-css highlight">.card<c- nf>:toggle</c-><c- p>(</c->show <c- m>0</c-><c- p>)</c-> <c- p>{</c->
   <c- c>/* Definitely *not* shown */</c->
 <c- p>}</c->
 </pre>
    </div>
    <h2 class="heading settled" data-level="5" id="toggle-visibility-property"><span class="secno">5. </span><span class="content"> Automatically Hiding With A Toggle</span><a class="self-link" href="#toggle-visibility-property"></a></h2>
-   <p>The <a class="property css" data-link-type="property" href="https://drafts.csswg.org/css-contain-2/#propdef-content-visibility" id="ref-for-propdef-content-visibility">content-visibility</a> property
+   <p>The <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-contain-2/#propdef-content-visibility" id="ref-for-propdef-content-visibility">content-visibility</a> property
 	allows an element to suppress the layout and rendering of its contents,
 	similar to <a class="css" data-link-type="propdesc" href="https://drafts.csswg.org/css-display-3/#propdef-display" id="ref-for-propdef-display">display: none</a>;
 	however, its <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-contain-2/#valdef-content-visibility-auto" id="ref-for-valdef-content-visibility-auto">auto</a> value allows the contents
@@ -1415,11 +1467,11 @@ we can also automatically infer all the tab-set ARIA roles</p>
 	or tab order,
 	and then to automatically become visible
 	when the element becomes <a data-link-type="dfn" href="https://drafts.csswg.org/css-contain-2/#relevant-to-the-user" id="ref-for-relevant-to-the-user">relevant to the user</a>.</p>
-   <p>A common use-case for <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle⑤⑤">toggles</a> is also to control whether an element is shown or hidden,
+   <p>A common use-case for <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle⑤⑦">toggles</a> is also to control whether an element is shown or hidden,
 	and in many cases it would also be useful to allow the contents of elements "hidden" in this way
 	to be accessible in the same ways.
 	To allow for this,
-	the <a class="property css" data-link-type="property" href="#propdef-toggle-visibility" id="ref-for-propdef-toggle-visibility①">toggle-visibility</a> property allows an element
+	the <a class="property" data-link-type="propdesc" href="#propdef-toggle-visibility" id="ref-for-propdef-toggle-visibility①">toggle-visibility</a> property allows an element
 	to both respond to and control a toggle
 	with its visibility.</p>
    <table class="def propdef" data-link-for-hint="toggle-visibility">
@@ -1429,7 +1481,7 @@ we can also automatically infer all the tab-set ARIA roles</p>
       <td><dfn class="dfn-paneled css" data-dfn-type="property" data-export id="propdef-toggle-visibility">toggle-visibility</dfn>
      <tr class="value">
       <th><a href="https://www.w3.org/TR/css-values/#value-defs">Value:</a>
-      <td class="prod">normal <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one" id="ref-for-comb-one④">|</a> toggle <a class="production css" data-link-type="type" href="#typedef-toggle-toggle-name" id="ref-for-typedef-toggle-toggle-name①⑥">&lt;toggle-name></a> 
+      <td class="prod">normal <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one" id="ref-for-comb-one⑨">|</a> toggle <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#identifier-value" id="ref-for-identifier-value②⑧">&lt;custom-ident></a> 
      <tr>
       <th><a href="https://www.w3.org/TR/css-cascade/#initial-values">Initial:</a>
       <td>normal 
@@ -1452,38 +1504,31 @@ we can also automatically infer all the tab-set ARIA roles</p>
       <th><a href="https://www.w3.org/TR/web-animations/#animation-type">Animation type:</a>
       <td>not animatable 
    </table>
-   <p>The <a class="property css" data-link-type="property" href="#propdef-toggle-visibility" id="ref-for-propdef-toggle-visibility②">toggle-visibility</a> property
-	allows an element to automatically tie its display to a particular <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle⑤⑥">toggle</a> bi-directionally,
+   <p>The <a class="property" data-link-type="propdesc" href="#propdef-toggle-visibility" id="ref-for-propdef-toggle-visibility②">toggle-visibility</a> property
+	allows an element to automatically tie its display to a particular <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle⑤⑧">toggle</a> bi-directionally,
 	while still exposing its contents to be focused, found-in-page, etc.,
 	automatically showing itself when relevant.</p>
    <dl>
     <dt data-md><dfn class="css" data-dfn-for="toggle-visibility" data-dfn-type="value" data-export id="valdef-toggle-visibility-normal">normal<a class="self-link" href="#valdef-toggle-visibility-normal"></a></dfn>
     <dd data-md>
      <p>The property has no effect.</p>
-    <dt data-md><dfn class="css" data-dfn-for="toggle-visibility" data-dfn-type="value" data-export data-lt="toggle" id="valdef-toggle-visibility-toggle">toggle <a class="production css" data-link-type="type" href="#typedef-toggle-toggle-name" id="ref-for-typedef-toggle-toggle-name①⑦">&lt;toggle-name></a><a class="self-link" href="#valdef-toggle-visibility-toggle"></a></dfn>
+    <dt data-md><dfn class="css" data-dfn-for="toggle-visibility" data-dfn-type="value" data-export data-lt="toggle" id="valdef-toggle-visibility-toggle">toggle <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#identifier-value" id="ref-for-identifier-value②⑨">&lt;custom-ident></a><a class="self-link" href="#valdef-toggle-visibility-toggle"></a></dfn>
     <dd data-md>
-     <p>If the element is <a data-link-type="dfn" href="#toggle-in-scope" id="ref-for-toggle-in-scope⑥">in scope</a> for a <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle⑤⑦">toggle</a> of the given <a class="production css" data-link-type="type" href="#typedef-toggle-toggle-name" id="ref-for-typedef-toggle-toggle-name①⑧">&lt;toggle-name></a>,
-and that <span id="ref-for-css-toggle⑤⑧">toggle</span> is in the <a data-link-type="dfn" href="#toggle-inactive-state" id="ref-for-toggle-inactive-state④">inactive state</a>,
-the element and its descendants generate no <a data-link-type="dfn" href="https://drafts.csswg.org/css-display-3/#box" id="ref-for-box">boxes</a> or <a data-link-type="dfn" href="https://drafts.csswg.org/css-display-3/#text-run" id="ref-for-text-run">text runs</a>,
-similar to <a class="css" data-link-type="propdesc" href="https://drafts.csswg.org/css-display-3/#propdef-display" id="ref-for-propdef-display①">display: none</a>,
-but must still be available to user-agent features
-such as find-in-page, tab order navigation, etc.,
-and must be focusable as normal,
-similar to <a class="css" data-link-type="propdesc" href="https://drafts.csswg.org/css-contain-2/#propdef-content-visibility" id="ref-for-propdef-content-visibility①">content-visibility: auto</a>.</p>
-     <p>If the element starts being <a data-link-type="dfn" href="https://drafts.csswg.org/css-contain-2/#relevant-to-the-user" id="ref-for-relevant-to-the-user①">relevant to the user</a>,
+     <p>If the element is <a data-link-type="dfn" href="#toggle-in-scope" id="ref-for-toggle-in-scope⑥">in scope</a> for a <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle⑤⑨">toggle</a> whose name matches the <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#identifier-value" id="ref-for-identifier-value③⓪">&lt;custom-ident></a>,
+and that <span id="ref-for-css-toggle⑥⓪">toggle</span> is in the <a data-link-type="dfn" href="#toggle-inactive-state" id="ref-for-toggle-inactive-state③">inactive state</a>,
+then the element acts as if <a class="css" data-link-type="propdesc">content-visiblity: auto</a> is specified,
+except that being on-screen does not make it <a data-link-type="dfn" href="https://drafts.csswg.org/css-contain-2/#relevant-to-the-user" id="ref-for-relevant-to-the-user①">relevant to the user</a>.</p>
+     <p>If the element starts being <a data-link-type="dfn" href="https://drafts.csswg.org/css-contain-2/#relevant-to-the-user" id="ref-for-relevant-to-the-user②">relevant to the user</a>,
 it <a data-link-type="dfn" href="#fire-a-toggle-activation" id="ref-for-fire-a-toggle-activation①">fires</a> a <a data-link-type="dfn" href="#css-toggle-activation" id="ref-for-css-toggle-activation④">toggle activation</a>,
-with a <a data-link-type="dfn" href="#toggle-activation-name" id="ref-for-toggle-activation-name①">name</a> of the given <a class="production css" data-link-type="type" href="#typedef-toggle-toggle-name" id="ref-for-typedef-toggle-toggle-name①⑨">&lt;toggle-name></a> and a <a data-link-type="dfn" href="#toggle-activation-target-state" id="ref-for-toggle-activation-target-state②">target state</a> of 1.</p>
-     <p class="note" role="note"><span>Note:</span> If the <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle⑤⑨">toggle</a> is currently in an <a data-link-type="dfn" href="#toggle-inactive-state" id="ref-for-toggle-inactive-state⑤">inactive state</a> and thus not generating any boxes,
-it can’t become <a data-link-type="dfn" href="https://drafts.csswg.org/css-contain-2/#relevant-to-the-user" id="ref-for-relevant-to-the-user②">relevant to the user</a> due to being "on-screen"
-but the other options are still possible.</p>
-     <p class="note" role="note"><span>Note:</span> If the <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle⑥⓪">toggle</a> is in an <a data-link-type="dfn" href="#toggle-active-state" id="ref-for-toggle-active-state⑦">active state</a>,
-or the element can’t see the specified <span id="ref-for-css-toggle⑥①">toggle</span> at all,
+with a <a data-link-type="dfn" href="#toggle-activation-name" id="ref-for-toggle-activation-name②">name</a> of the given <a class="production css" data-link-type="type">&lt;toggle-name></a> and a <a data-link-type="dfn" href="#toggle-activation-event" id="ref-for-toggle-activation-event①">event</a> of ‘set 1’.</p>
+     <p class="note" role="note"><span>Note:</span> If the <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle⑥①">toggle</a> is in an <a data-link-type="dfn" href="#toggle-active-state" id="ref-for-toggle-active-state⑥">active state</a>,
+or the element can’t see the specified <span id="ref-for-css-toggle⑥②">toggle</span> at all,
 the element renders normally.</p>
    </dl>
    <div class="example" id="example-c7f898eb">
     <a class="self-link" href="#example-c7f898eb"></a> For example, an "accordion" display,
 		such as used for a page of FAQs,
-		can use <a class="property css" data-link-type="property" href="#propdef-toggle-visibility" id="ref-for-propdef-toggle-visibility③">toggle-visibility</a> to hide the answers by default,
+		can use <a class="property" data-link-type="propdesc" href="#propdef-toggle-visibility" id="ref-for-propdef-toggle-visibility③">toggle-visibility</a> to hide the answers by default,
 		but still make them accessible to find-in-page: 
 <pre class="lang-html highlight"><c- p>&lt;</c-><c- f>dl</c-> <c- e>class</c-><c- o>=</c-><c- s>accordion</c-><c- p>></c->
   <c- p>&lt;</c-><c- f>dt</c-><c- p>></c->Question 1?
@@ -1500,15 +1545,15 @@ the element renders normally.</p>
   <c- p>}</c->
 <c- p>&lt;/</c-><c- f>style</c-><c- p>></c->
 </pre>
-    <p>Each <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-dt-element" id="ref-for-the-dt-element">dt</a></code> establishes a separate "show" <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle⑥②">toggle</a>,
+    <p>Each <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-dt-element" id="ref-for-the-dt-element">dt</a></code> establishes a separate "show" <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle⑥③">toggle</a>,
 		with all the defaults filling in to produce a standard "checkbox"-like behavior,
-		all initially in the <a data-link-type="dfn" href="#toggle-inactive-state" id="ref-for-toggle-inactive-state⑥">inactive state</a>.
+		all initially in the <a data-link-type="dfn" href="#toggle-inactive-state" id="ref-for-toggle-inactive-state④">inactive state</a>.
 		Each <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-dt-element" id="ref-for-the-dt-element①">dt</a></code> can be activated to show or hide the following answer.</p>
-    <p>Each <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-dd-element" id="ref-for-the-dd-element">dd</a></code> can see the <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle⑥③">toggle</a> established by its preceding <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-dt-element" id="ref-for-the-dt-element②">dt</a></code>,
+    <p>Each <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-dd-element" id="ref-for-the-dd-element">dd</a></code> can see the <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle⑥④">toggle</a> established by its preceding <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-dt-element" id="ref-for-the-dt-element②">dt</a></code>,
 		and will start out not rendering.
 		If the user searches on the page for a term,
 		or visits the page from a link with an #anchor linking into one of the answers,
-		the relevant answer will automatically activate the <span id="ref-for-css-toggle⑥④">toggle</span>,
+		the relevant answer will automatically activate the <span id="ref-for-css-toggle⑥⑤">toggle</span>,
 		causing the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-dd-element" id="ref-for-the-dd-element①">dd</a></code> to become visible.</p>
    </div>
    <p class="issue" id="issue-8c43f943"><a class="self-link" href="#issue-8c43f943"></a> Define ordering of activations,
@@ -1516,24 +1561,49 @@ the element renders normally.</p>
 	and they’re all part of a <a data-link-type="dfn" href="#css-toggle-group" id="ref-for-css-toggle-group①⑨">toggle group</a>,
 	which one "wins" is well-defined.</p>
    <h2 class="heading settled" data-level="6" id="dom"><span class="secno">6. </span><span class="content"> Scripting API</span><a class="self-link" href="#dom"></a></h2>
-   <div class="issue" id="issue-adf5ca30">
-    <a class="self-link" href="#issue-adf5ca30"></a> TODO 
-    <ul>
-     <li data-md>
-      <p>Expose a map of toggles on an element, with {name=>rest of <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle⑥⑤">toggle</a> info}.
-(Or just a list of toggles, with name built into the object?)</p>
-     <li data-md>
-      <p>Ability to create toggles manually.
-(Tho without an accompanying <a class="property css" data-link-type="property" href="#propdef-toggle-root" id="ref-for-propdef-toggle-root①⓪">toggle-root</a>,
-you just get the <a data-link-type="dfn" href="#default-toggle-specifier" id="ref-for-default-toggle-specifier①">default toggle specifier</a> when it’s activated.)</p>
-     <li data-md>
-      <p>Ability to delete toggles manually.
-(Tho if you don’t remove the accompanying <a class="property css" data-link-type="property" href="#propdef-toggle-root" id="ref-for-propdef-toggle-root①①">toggle-root</a>,
-it’ll respawn on the next rendering tick.)</p>
-     <li data-md>
-      <p>Ability to set toggle state manually.</p>
-    </ul>
-   </div>
+<pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="https://dom.spec.whatwg.org/#element" id="ref-for-element"><c- g>Element</c-></a> {
+  <c- b>attribute</c-> <a data-link-type="idl-name" href="#csstogglemap" id="ref-for-csstogglemap"><c- n>CSSToggleMap</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="Element" data-dfn-type="attribute" data-export data-type="CSSToggleMap" id="dom-element-toggles"><code><c- g>toggles</c-></code></dfn>;
+};
+
+<c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="csstogglemap"><code><c- g>CSSToggleMap</c-></code></dfn> {
+  <c- b>maplike</c->&lt;<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-DOMString" id="ref-for-idl-DOMString"><c- b>DOMString</c-></a>, <a data-link-type="idl-name" href="#csstoggle" id="ref-for-csstoggle"><c- n>CSSToggle</c-></a>>;
+
+  <a data-link-type="idl-name" href="#csstogglemap" id="ref-for-csstogglemap①"><c- n>CSSToggleMap</c-></a> <dfn class="idl-code" data-dfn-for="CSSToggleMap" data-dfn-type="method" data-export data-lt="set(name, options)" id="dom-csstogglemap-set"><code><c- g>set</c-></code><a class="self-link" href="#dom-csstogglemap-set"></a></dfn>(<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-DOMString" id="ref-for-idl-DOMString①"><c- b>DOMString</c-></a> <dfn class="idl-code" data-dfn-for="CSSToggleMap/set(name, options)" data-dfn-type="argument" data-export id="dom-csstogglemap-set-name-options-name"><code><c- g>name</c-></code><a class="self-link" href="#dom-csstogglemap-set-name-options-name"></a></dfn>, <a data-link-type="idl-name" href="#dictdef-csstoggledata" id="ref-for-dictdef-csstoggledata"><c- n>CSSToggleData</c-></a> <dfn class="idl-code" data-dfn-for="CSSToggleMap/set(name, options)" data-dfn-type="argument" data-export id="dom-csstogglemap-set-name-options-options"><code><c- g>options</c-></code><a class="self-link" href="#dom-csstogglemap-set-name-options-options"></a></dfn>);
+};
+
+<c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="csstoggle"><code><c- g>CSSToggle</c-></code></dfn> {
+  <c- b>attribute</c-> <a data-link-type="idl-name"><c- n>int</c-></a> <dfn class="idl-code" data-dfn-for="CSSToggle" data-dfn-type="attribute" data-export data-type="int" id="dom-csstoggle-value"><code><c- g>value</c-></code><a class="self-link" href="#dom-csstoggle-value"></a></dfn>;
+  <c- b>attribute</c-> <a data-link-type="idl-name"><c- n>int</c-></a> <dfn class="idl-code" data-dfn-for="CSSToggle" data-dfn-type="attribute" data-export data-type="int" id="dom-csstoggle-maximum"><code><c- g>maximum</c-></code><a class="self-link" href="#dom-csstoggle-maximum"></a></dfn>;
+  <c- b>attribute</c-> <a data-link-type="idl-name"><c- n>bool</c-></a> <dfn class="idl-code" data-dfn-for="CSSToggle" data-dfn-type="attribute" data-export data-type="bool" id="dom-csstoggle-group"><code><c- g>group</c-></code><a class="self-link" href="#dom-csstoggle-group"></a></dfn>;
+  <c- b>attribute</c-> <a data-link-type="idl-name" href="#enumdef-csstogglescope" id="ref-for-enumdef-csstogglescope"><c- n>CSSToggleScope</c-></a> <dfn class="idl-code" data-dfn-for="CSSToggle" data-dfn-type="attribute" data-export data-type="CSSToggleScope" id="dom-csstoggle-scope"><code><c- g>scope</c-></code><a class="self-link" href="#dom-csstoggle-scope"></a></dfn>;
+  <c- b>attribute</c-> <a data-link-type="idl-name" href="#enumdef-csstogglecycle" id="ref-for-enumdef-csstogglecycle"><c- n>CSSToggleCycle</c-></a> <dfn class="idl-code" data-dfn-for="CSSToggle" data-dfn-type="attribute" data-export data-type="CSSToggleCycle" id="dom-csstoggle-cycle"><code><c- g>cycle</c-></code><a class="self-link" href="#dom-csstoggle-cycle"></a></dfn>;
+
+  <dfn class="idl-code" data-dfn-for="CSSToggle" data-dfn-type="constructor" data-export data-lt="CSSToggle(options)|constructor(options)" id="dom-csstoggle-csstoggle"><code><c- g>constructor</c-></code><a class="self-link" href="#dom-csstoggle-csstoggle"></a></dfn>(<a data-link-type="idl-name" href="#dictdef-csstoggledata" id="ref-for-dictdef-csstoggledata①"><c- n>CSSToggleData</c-></a> <dfn class="idl-code" data-dfn-for="CSSToggle/CSSToggle(options), CSSToggle/constructor(options)" data-dfn-type="argument" data-export id="dom-csstoggle-csstoggle-options-options"><code><c- g>options</c-></code><a class="self-link" href="#dom-csstoggle-csstoggle-options-options"></a></dfn>);
+};
+
+<c- b>dictionary</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export id="dictdef-csstoggledata"><code><c- g>CSSToggleData</c-></code></dfn> {
+  <a data-link-type="idl-name"><c- n>int</c-></a> <dfn class="idl-code" data-dfn-for="CSSToggleData" data-dfn-type="dict-member" data-export data-type="int " id="dom-csstoggledata-value"><code><c- g>value</c-></code><a class="self-link" href="#dom-csstoggledata-value"></a></dfn>;
+  <a data-link-type="idl-name"><c- n>int</c-></a> <dfn class="idl-code" data-dfn-for="CSSToggleData" data-dfn-type="dict-member" data-export data-type="int " id="dom-csstoggledata-maximum"><code><c- g>maximum</c-></code><a class="self-link" href="#dom-csstoggledata-maximum"></a></dfn>;
+  <a data-link-type="idl-name"><c- n>bool</c-></a> <dfn class="idl-code" data-dfn-for="CSSToggleData" data-dfn-type="dict-member" data-export data-type="bool " id="dom-csstoggledata-group"><code><c- g>group</c-></code><a class="self-link" href="#dom-csstoggledata-group"></a></dfn>;
+  <a data-link-type="idl-name" href="#enumdef-csstogglescope" id="ref-for-enumdef-csstogglescope①"><c- n>CSSToggleScope</c-></a> <dfn class="idl-code" data-dfn-for="CSSToggleData" data-dfn-type="dict-member" data-export data-type="CSSToggleScope " id="dom-csstoggledata-scope"><code><c- g>scope</c-></code><a class="self-link" href="#dom-csstoggledata-scope"></a></dfn>;
+  <a data-link-type="idl-name" href="#enumdef-csstogglecycle" id="ref-for-enumdef-csstogglecycle①"><c- n>CSSToggleCycle</c-></a> <dfn class="idl-code" data-dfn-for="CSSToggleData" data-dfn-type="dict-member" data-export data-type="CSSToggleCycle " id="dom-csstoggledata-cycle"><code><c- g>cycle</c-></code><a class="self-link" href="#dom-csstoggledata-cycle"></a></dfn>;
+};
+
+<c- b>enum</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="enum" data-export id="enumdef-csstogglescope"><code><c- g>CSSToggleScope</c-></code></dfn> {
+  <dfn class="idl-code" data-dfn-for="CSSToggleScope" data-dfn-type="enum-value" data-export id="dom-csstogglescope-narrow"><code><c- s>"narrow"</c-></code><a class="self-link" href="#dom-csstogglescope-narrow"></a></dfn>,
+  <dfn class="idl-code" data-dfn-for="CSSToggleScope" data-dfn-type="enum-value" data-export id="dom-csstogglescope-wide"><code><c- s>"wide"</c-></code><a class="self-link" href="#dom-csstogglescope-wide"></a></dfn>,
+};
+
+<c- b>enum</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="enum" data-export id="enumdef-csstogglecycle"><code><c- g>CSSToggleCycle</c-></code></dfn> {
+  <dfn class="idl-code" data-dfn-for="CSSToggleCycle" data-dfn-type="enum-value" data-export id="dom-csstogglecycle-cycle"><code><c- s>"cycle"</c-></code><a class="self-link" href="#dom-csstogglecycle-cycle"></a></dfn>,
+  <dfn class="idl-code" data-dfn-for="CSSToggleCycle" data-dfn-type="enum-value" data-export id="dom-csstogglecycle-cycle-on"><code><c- s>"cycle-on"</c-></code><a class="self-link" href="#dom-csstogglecycle-cycle-on"></a></dfn>,
+}
+</pre>
+   <p>The <code class="idl"><a data-link-type="idl" href="#dom-element-toggles" id="ref-for-dom-element-toggles①">toggles</a></code> attribute on <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element①">Element</a></code>s
+	exposes the <a data-link-type="dfn" href="#element-established-toggles" id="ref-for-element-established-toggles">established toggles</a> on the element:
+	each <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle⑥⑥">toggle</a> is represented by an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry" id="ref-for-map-entry">entry</a> in the map,
+	with its key equal to its name
+	and its value a <code class="idl"><a data-link-type="idl" href="#csstoggle" id="ref-for-csstoggle①">CSSToggle</a></code> representing the state of the <span id="ref-for-css-toggle⑥⑦">toggle</span>.</p>
   </main>
   <h2 class="no-ref no-num heading settled" id="w3c-conformance"><span class="content"> Conformance</span><a class="self-link" href="#w3c-conformance"></a></h2>
   <h3 class="no-ref heading settled" id="w3c-conventions"><span class="content"> Document conventions</span><a class="self-link" href="#w3c-conventions"></a></h3>
@@ -1622,14 +1692,34 @@ it’ll respawn on the next rendering tick.)</p>
   <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
   <ul class="index">
    <li><a href="#toggle-active-state">active state</a><span>, in § 2</span>
+   <li><a href="#dom-csstoggle-csstoggle">constructor(options)</a><span>, in § 6</span>
+   <li><a href="#csstoggle">CSSToggle</a><span>, in § 6</span>
+   <li><a href="#enumdef-csstogglecycle">CSSToggleCycle</a><span>, in § 6</span>
+   <li><a href="#dictdef-csstoggledata">CSSToggleData</a><span>, in § 6</span>
+   <li><a href="#csstogglemap">CSSToggleMap</a><span>, in § 6</span>
+   <li><a href="#dom-csstoggle-csstoggle">CSSToggle(options)</a><span>, in § 6</span>
+   <li><a href="#enumdef-csstogglescope">CSSToggleScope</a><span>, in § 6</span>
+   <li><a href="#valdef-toggle-group-custom-ident">&lt;custom-ident></a><span>, in § 3.2</span>
+   <li><a href="#dom-csstogglecycle-cycle">"cycle"</a><span>, in § 6</span>
+   <li>
+    cycle
+    <ul>
+     <li><a href="#dom-csstoggle-cycle">attribute for CSSToggle</a><span>, in § 6</span>
+     <li><a href="#dom-csstoggledata-cycle">dict-member for CSSToggleData</a><span>, in § 6</span>
+    </ul>
+   <li><a href="#dom-csstogglecycle-cycle-on">"cycle-on"</a><span>, in § 6</span>
    <li><a href="#default-toggle-specifier">default toggle specifier</a><span>, in § 2</span>
-   <li><a href="#fire-a-toggle-activation">fire</a><span>, in § 3.2</span>
-   <li><a href="#fire-a-toggle-activation">fire a toggle activation</a><span>, in § 3.2</span>
+   <li><a href="#element-established-toggles">established toggles</a><span>, in § 3.1</span>
+   <li><a href="#toggle-activation-event">event</a><span>, in § 3.3</span>
+   <li><a href="#fire-a-toggle-activation">fire</a><span>, in § 3.3</span>
+   <li><a href="#fire-a-toggle-activation">fire a toggle activation</a><span>, in § 3.3</span>
    <li>
     group
     <ul>
+     <li><a href="#dom-csstoggle-group">attribute for CSSToggle</a><span>, in § 6</span>
      <li><a href="#toggle-group">dfn for toggle</a><span>, in § 2</span>
      <li><a href="#toggle-specifier-group">dfn for toggle specifier</a><span>, in § 2</span>
+     <li><a href="#dom-csstoggledata-group">dict-member for CSSToggleData</a><span>, in § 6</span>
      <li><a href="#valdef-toggle-root-group">value for toggle-root</a><span>, in § 3</span>
     </ul>
    <li><a href="#css-implicit-toggle-group">implicit toggle group</a><span>, in § 2</span>
@@ -1637,12 +1727,19 @@ it’ll respawn on the next rendering tick.)</p>
    <li><a href="#toggle-in-a-toggle-group">in a toggle group</a><span>, in § 2</span>
    <li><a href="#toggle-specifier-initial-state">initial state</a><span>, in § 2</span>
    <li><a href="#toggle-in-scope">in scope</a><span>, in § 2</span>
+   <li><a href="#toggle-match-state">match state</a><span>, in § 2</span>
+   <li>
+    maximum
+    <ul>
+     <li><a href="#dom-csstoggle-maximum">attribute for CSSToggle</a><span>, in § 6</span>
+     <li><a href="#dom-csstoggledata-maximum">dict-member for CSSToggleData</a><span>, in § 6</span>
+    </ul>
    <li><a href="#toggle-specifier-maximum-state">maximum state</a><span>, in § 2</span>
    <li>
     name
     <ul>
      <li><a href="#toggle-name">dfn for toggle</a><span>, in § 2</span>
-     <li><a href="#toggle-activation-name">dfn for toggle activation</a><span>, in § 3.2</span>
+     <li><a href="#toggle-activation-name">dfn for toggle activation</a><span>, in § 3.3</span>
      <li><a href="#toggle-group-name">dfn for toggle group</a><span>, in § 2</span>
      <li><a href="#toggle-specifier-name">dfn for toggle specifier</a><span>, in § 2</span>
     </ul>
@@ -1651,29 +1748,34 @@ it’ll respawn on the next rendering tick.)</p>
     <ul>
      <li><a href="#toggle-narrow">dfn for toggle</a><span>, in § 2</span>
      <li><a href="#toggle-group-narrow">dfn for toggle group</a><span>, in § 2</span>
+     <li><a href="#dom-csstogglescope-narrow">enum-value for CSSToggleScope</a><span>, in § 6</span>
     </ul>
    <li><a href="#toggle-narrow-scope">narrow scope</a><span>, in § 2</span>
    <li>
     none
     <ul>
-     <li><a href="#valdef-toggle-group-none">value for toggle-group</a><span>, in § 3.1</span>
+     <li><a href="#valdef-toggle-group-none">value for toggle-group</a><span>, in § 3.2</span>
      <li><a href="#valdef-toggle-root-none">value for toggle-root</a><span>, in § 3</span>
-     <li><a href="#valdef-toggle-trigger-none">value for toggle-trigger</a><span>, in § 3.2</span>
+     <li><a href="#valdef-toggle-trigger-none">value for toggle-trigger</a><span>, in § 3.3</span>
     </ul>
    <li><a href="#valdef-toggle-visibility-normal">normal</a><span>, in § 5</span>
+   <li><a href="#toggle-specifier-overflow">overflow</a><span>, in § 2</span>
    <li>
     scope
     <ul>
+     <li><a href="#dom-csstoggle-scope">attribute for CSSToggle</a><span>, in § 6</span>
      <li><a href="#toggle-scope">dfn for toggle</a><span>, in § 2</span>
      <li><a href="#toggle-group-scope">dfn for toggle group</a><span>, in § 2</span>
      <li><a href="#toggle-specifier-scope">dfn for toggle specifier</a><span>, in § 2</span>
+     <li><a href="#dom-csstoggledata-scope">dict-member for CSSToggleData</a><span>, in § 6</span>
     </ul>
    <li>
     self
     <ul>
-     <li><a href="#valdef-toggle-group-toggle-name">value for toggle-group</a><span>, in § 3.1</span>
+     <li><a href="#valdef-toggle-group-custom-ident">value for toggle-group</a><span>, in § 3.2</span>
      <li><a href="#valdef-toggle-root-self">value for toggle-root</a><span>, in § 3</span>
     </ul>
+   <li><a href="#dom-csstogglemap-set">set(name, options)</a><span>, in § 6</span>
    <li><a href="#toggle-state">state</a><span>, in § 2</span>
    <li>
     state names
@@ -1681,43 +1783,41 @@ it’ll respawn on the next rendering tick.)</p>
      <li><a href="#toggle-state-names">dfn for toggle</a><span>, in § 2</span>
      <li><a href="#toggle-specifier-state-names">dfn for toggle specifier</a><span>, in § 2</span>
     </ul>
-   <li>
-    sticky
-    <ul>
-     <li><a href="#toggle-specifier-sticky">dfn for toggle specifier</a><span>, in § 2</span>
-     <li><a href="#valdef-toggle-root-sticky">value for toggle-root</a><span>, in § 3</span>
-    </ul>
-   <li><a href="#toggle-activation-target-state">target state</a><span>, in § 3.2</span>
    <li><a href="#selectordef-toggle">:toggle()</a><span>, in § 4</span>
    <li>
     toggle
     <ul>
-     <li><a href="#propdef-toggle">(property)</a><span>, in § 3.3</span>
+     <li><a href="#propdef-toggle">(property)</a><span>, in § 3.4</span>
      <li><a href="#css-toggle">dfn for CSS</a><span>, in § 2</span>
      <li><a href="#valdef-toggle-visibility-toggle">value for toggle-visibility</a><span>, in § 5</span>
     </ul>
-   <li><a href="#css-toggle-activation">toggle activation</a><span>, in § 3.2</span>
+   <li><a href="#css-toggle-activation">toggle activation</a><span>, in § 3.3</span>
    <li><a href="#css-toggle-group">toggle group</a><span>, in § 2</span>
-   <li><a href="#propdef-toggle-group">toggle-group</a><span>, in § 3.1</span>
-   <li>
-    &lt;toggle-name>
-    <ul>
-     <li><a href="#typedef-toggle-toggle-name">type for toggle</a><span>, in § 2</span>
-     <li><a href="#valdef-toggle-group-toggle-name">value for toggle-group</a><span>, in § 3.1</span>
-    </ul>
-   <li><a href="#valdef-toggle-trigger-toggle-name-integer-0">&lt;toggle-name> &lt;integer [0,∞]>?</a><span>, in § 3.2</span>
-   <li><a href="#toggle-root">toggle root</a><span>, in § 1</span>
+   <li><a href="#propdef-toggle-group">toggle-group</a><span>, in § 3.2</span>
+   <li><a href="#typedef-toggle-overflow">&lt;toggle-overflow></a><span>, in § 3</span>
+   <li><a href="#toggle-root">toggle root</a><span>, in § 1.1</span>
    <li><a href="#propdef-toggle-root">toggle-root</a><span>, in § 3</span>
+   <li><a href="#dom-element-toggles">toggles</a><span>, in § 6</span>
    <li><a href="#typedef-toggle-specifier">&lt;toggle-specifier></a><span>, in § 3</span>
    <li><a href="#valdef-toggle-root-toggle-specifier">&lt;toggle-specifier>#</a><span>, in § 3</span>
    <li><a href="#toggle-toggle-specifier">toggle specifier</a><span>, in § 2</span>
-   <li><a href="#propdef-toggle-trigger">toggle-trigger</a><span>, in § 3.2</span>
+   <li><a href="#typedef-toggle-state">&lt;toggle-state></a><span>, in § 3</span>
+   <li><a href="#typedef-toggle-states">&lt;toggle-states></a><span>, in § 3</span>
+   <li><a href="#propdef-toggle-trigger">toggle-trigger</a><span>, in § 3.3</span>
    <li><a href="#propdef-toggle-visibility">toggle-visibility</a><span>, in § 5</span>
+   <li><a href="#typedef-trigger-action">&lt;trigger-action></a><span>, in § 3.3</span>
+   <li>
+    value
+    <ul>
+     <li><a href="#dom-csstoggle-value">attribute for CSSToggle</a><span>, in § 6</span>
+     <li><a href="#dom-csstoggledata-value">dict-member for CSSToggleData</a><span>, in § 6</span>
+    </ul>
    <li>
     "wide"
     <ul>
      <li><a href="#toggle-wide">dfn for toggle</a><span>, in § 2</span>
      <li><a href="#toggle-group-wide">dfn for toggle group</a><span>, in § 2</span>
+     <li><a href="#dom-csstogglescope-wide">enum-value for CSSToggleScope</a><span>, in § 6</span>
     </ul>
    <li><a href="#toggle-wide-scope">wide scope</a><span>, in § 2</span>
   </ul>
@@ -1732,7 +1832,7 @@ Automatically Hiding With A Toggle</a>
    <a href="https://drafts.csswg.org/css-contain-2/#propdef-content-visibility">https://drafts.csswg.org/css-contain-2/#propdef-content-visibility</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-content-visibility">5. 
-Automatically Hiding With A Toggle</a> <a href="#ref-for-propdef-content-visibility①">(2)</a>
+Automatically Hiding With A Toggle</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-relevant-to-the-user">
@@ -1742,18 +1842,11 @@ Automatically Hiding With A Toggle</a> <a href="#ref-for-propdef-content-visibil
 Automatically Hiding With A Toggle</a> <a href="#ref-for-relevant-to-the-user①">(2)</a> <a href="#ref-for-relevant-to-the-user②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-box">
-   <a href="https://drafts.csswg.org/css-display-3/#box">https://drafts.csswg.org/css-display-3/#box</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-box">5. 
-Automatically Hiding With A Toggle</a>
-   </ul>
-  </aside>
   <aside class="dfn-panel" data-for="term-for-propdef-display">
    <a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-display">5. 
-Automatically Hiding With A Toggle</a> <a href="#ref-for-propdef-display①">(2)</a>
+Automatically Hiding With A Toggle</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-elements">
@@ -1761,13 +1854,8 @@ Automatically Hiding With A Toggle</a> <a href="#ref-for-propdef-display①">(2)
    <ul>
     <li><a href="#ref-for-elements">2. 
 Toggle Concepts</a> <a href="#ref-for-elements①">(2)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-text-run">
-   <a href="https://drafts.csswg.org/css-display-3/#text-run">https://drafts.csswg.org/css-display-3/#text-run</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-text-run">5. 
-Automatically Hiding With A Toggle</a>
+    <li><a href="#ref-for-elements②">3.1. 
+Toggle Creation Details</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-mult-comma">
@@ -1775,35 +1863,43 @@ Automatically Hiding With A Toggle</a>
    <ul>
     <li><a href="#ref-for-mult-comma">3. 
 Creating a Toggle: the toggle-root property</a>
-    <li><a href="#ref-for-mult-comma①">3.1. 
+    <li><a href="#ref-for-mult-comma①">3.2. 
 Linking Toggle States: the toggle-group property</a>
-    <li><a href="#ref-for-mult-comma②">3.2. 
+    <li><a href="#ref-for-mult-comma②">3.3. 
 Activating a Toggle: the toggle-trigger property</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-mult-zero-plus">
+   <a href="https://drafts.csswg.org/css-values-4/#mult-zero-plus">https://drafts.csswg.org/css-values-4/#mult-zero-plus</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-mult-zero-plus">3. 
+Creating a Toggle: the toggle-root property</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-identifier-value">
    <a href="https://drafts.csswg.org/css-values-4/#identifier-value">https://drafts.csswg.org/css-values-4/#identifier-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-identifier-value">2. 
-Toggle Concepts</a> <a href="#ref-for-identifier-value①">(2)</a>
+Toggle Concepts</a> <a href="#ref-for-identifier-value①">(2)</a> <a href="#ref-for-identifier-value②">(3)</a> <a href="#ref-for-identifier-value③">(4)</a> <a href="#ref-for-identifier-value④">(5)</a> <a href="#ref-for-identifier-value⑤">(6)</a> <a href="#ref-for-identifier-value⑥">(7)</a> <a href="#ref-for-identifier-value⑦">(8)</a> <a href="#ref-for-identifier-value⑧">(9)</a> <a href="#ref-for-identifier-value⑨">(10)</a> <a href="#ref-for-identifier-value①⓪">(11)</a> <a href="#ref-for-identifier-value①①">(12)</a> <a href="#ref-for-identifier-value①②">(13)</a> <a href="#ref-for-identifier-value①③">(14)</a> <a href="#ref-for-identifier-value①④">(15)</a> <a href="#ref-for-identifier-value①⑤">(16)</a>
+    <li><a href="#ref-for-identifier-value①⑥">3. 
+Creating a Toggle: the toggle-root property</a> <a href="#ref-for-identifier-value①⑦">(2)</a> <a href="#ref-for-identifier-value①⑧">(3)</a> <a href="#ref-for-identifier-value①⑨">(4)</a> <a href="#ref-for-identifier-value②⓪">(5)</a>
+    <li><a href="#ref-for-identifier-value②①">3.2. 
+Linking Toggle States: the toggle-group property</a> <a href="#ref-for-identifier-value②②">(2)</a> <a href="#ref-for-identifier-value②③">(3)</a>
+    <li><a href="#ref-for-identifier-value②④">3.3. 
+Activating a Toggle: the toggle-trigger property</a> <a href="#ref-for-identifier-value②⑤">(2)</a>
+    <li><a href="#ref-for-identifier-value②⑥">4. 
+Selecting Elements Based on Toggle State: the :toggle() pseudo-class</a> <a href="#ref-for-identifier-value②⑦">(2)</a>
+    <li><a href="#ref-for-identifier-value②⑧">5. 
+Automatically Hiding With A Toggle</a> <a href="#ref-for-identifier-value②⑨">(2)</a> <a href="#ref-for-identifier-value③⓪">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-integer-value">
    <a href="https://drafts.csswg.org/css-values-4/#integer-value">https://drafts.csswg.org/css-values-4/#integer-value</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-integer-value">3. 
-Creating a Toggle: the toggle-root property</a> <a href="#ref-for-integer-value①">(2)</a> <a href="#ref-for-integer-value②">(3)</a> <a href="#ref-for-integer-value③">(4)</a> <a href="#ref-for-integer-value④">(5)</a> <a href="#ref-for-integer-value⑤">(6)</a>
-    <li><a href="#ref-for-integer-value⑥">3.2. 
-Activating a Toggle: the toggle-trigger property</a> <a href="#ref-for-integer-value⑦">(2)</a> <a href="#ref-for-integer-value⑧">(3)</a>
-    <li><a href="#ref-for-integer-value⑨">4. 
-Selecting Elements Based on Toggle State: the :toggle() pseudo-class</a> <a href="#ref-for-integer-value①⓪">(2)</a> <a href="#ref-for-integer-value①①">(3)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-string-value">
-   <a href="https://drafts.csswg.org/css-values-4/#string-value">https://drafts.csswg.org/css-values-4/#string-value</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-string-value">2. 
-Toggle Concepts</a> <a href="#ref-for-string-value①">(2)</a>
+    <li><a href="#ref-for-integer-value">2. 
+Toggle Concepts</a> <a href="#ref-for-integer-value①">(2)</a> <a href="#ref-for-integer-value②">(3)</a> <a href="#ref-for-integer-value③">(4)</a> <a href="#ref-for-integer-value④">(5)</a> <a href="#ref-for-integer-value⑤">(6)</a> <a href="#ref-for-integer-value⑥">(7)</a> <a href="#ref-for-integer-value⑦">(8)</a>
+    <li><a href="#ref-for-integer-value⑧">3. 
+Creating a Toggle: the toggle-root property</a> <a href="#ref-for-integer-value⑨">(2)</a> <a href="#ref-for-integer-value①⓪">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-mult-opt">
@@ -1811,9 +1907,9 @@ Toggle Concepts</a> <a href="#ref-for-string-value①">(2)</a>
    <ul>
     <li><a href="#ref-for-mult-opt">3. 
 Creating a Toggle: the toggle-root property</a> <a href="#ref-for-mult-opt①">(2)</a>
-    <li><a href="#ref-for-mult-opt②">3.1. 
+    <li><a href="#ref-for-mult-opt②">3.2. 
 Linking Toggle States: the toggle-group property</a>
-    <li><a href="#ref-for-mult-opt③">3.2. 
+    <li><a href="#ref-for-mult-opt③">3.3. 
 Activating a Toggle: the toggle-trigger property</a>
     <li><a href="#ref-for-mult-opt④">4. 
 Selecting Elements Based on Toggle State: the :toggle() pseudo-class</a>
@@ -1822,15 +1918,13 @@ Selecting Elements Based on Toggle State: the :toggle() pseudo-class</a>
   <aside class="dfn-panel" data-for="term-for-comb-one">
    <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-comb-one">2. 
-Toggle Concepts</a>
-    <li><a href="#ref-for-comb-one①">3. 
-Creating a Toggle: the toggle-root property</a>
-    <li><a href="#ref-for-comb-one②">3.1. 
+    <li><a href="#ref-for-comb-one">3. 
+Creating a Toggle: the toggle-root property</a> <a href="#ref-for-comb-one①">(2)</a> <a href="#ref-for-comb-one②">(3)</a> <a href="#ref-for-comb-one③">(4)</a> <a href="#ref-for-comb-one④">(5)</a>
+    <li><a href="#ref-for-comb-one⑤">3.2. 
 Linking Toggle States: the toggle-group property</a>
-    <li><a href="#ref-for-comb-one③">3.2. 
-Activating a Toggle: the toggle-trigger property</a>
-    <li><a href="#ref-for-comb-one④">5. 
+    <li><a href="#ref-for-comb-one⑥">3.3. 
+Activating a Toggle: the toggle-trigger property</a> <a href="#ref-for-comb-one⑦">(2)</a> <a href="#ref-for-comb-one⑧">(3)</a>
+    <li><a href="#ref-for-comb-one⑨">5. 
 Automatically Hiding With A Toggle</a>
    </ul>
   </aside>
@@ -1839,6 +1933,13 @@ Automatically Hiding With A Toggle</a>
    <ul>
     <li><a href="#ref-for-comb-any">3. 
 Creating a Toggle: the toggle-root property</a> <a href="#ref-for-comb-any①">(2)</a> <a href="#ref-for-comb-any②">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-element">
+   <a href="https://dom.spec.whatwg.org/#element">https://dom.spec.whatwg.org/#element</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-element">6. 
+Scripting API</a> <a href="#ref-for-element①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-tree-descendant">
@@ -1858,7 +1959,7 @@ Toggle Concepts</a>
   <aside class="dfn-panel" data-for="term-for-concept-tree-parent">
    <a href="https://dom.spec.whatwg.org/#concept-tree-parent">https://dom.spec.whatwg.org/#concept-tree-parent</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-tree-parent">3.2. 
+    <li><a href="#ref-for-concept-tree-parent">3.3. 
 Activating a Toggle: the toggle-trigger property</a>
    </ul>
   </aside>
@@ -1872,7 +1973,7 @@ Toggle Concepts</a>
   <aside class="dfn-panel" data-for="term-for-concept-tree-previous-sibling">
    <a href="https://dom.spec.whatwg.org/#concept-tree-previous-sibling">https://dom.spec.whatwg.org/#concept-tree-previous-sibling</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-tree-previous-sibling">3.2. 
+    <li><a href="#ref-for-concept-tree-previous-sibling">3.3. 
 Activating a Toggle: the toggle-trigger property</a>
    </ul>
   </aside>
@@ -1907,22 +2008,22 @@ Automatically Hiding With A Toggle</a> <a href="#ref-for-the-dt-element①">(2)<
   <aside class="dfn-panel" data-for="term-for-update-the-rendering">
    <a href="https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering">https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-update-the-rendering">3. 
-Creating a Toggle: the toggle-root property</a>
+    <li><a href="#ref-for-update-the-rendering">3.1. 
+Toggle Creation Details</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-boolean">
    <a href="https://infra.spec.whatwg.org/#boolean">https://infra.spec.whatwg.org/#boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-boolean">2. 
-Toggle Concepts</a> <a href="#ref-for-boolean①">(2)</a>
+Toggle Concepts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string-is">
-   <a href="https://infra.spec.whatwg.org/#string-is">https://infra.spec.whatwg.org/#string-is</a><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="term-for-map-entry">
+   <a href="https://infra.spec.whatwg.org/#map-entry">https://infra.spec.whatwg.org/#map-entry</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-string-is">2. 
-Toggle Concepts</a>
+    <li><a href="#ref-for-map-entry">6. 
+Scripting API</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-struct-item">
@@ -1941,13 +2042,6 @@ Creating a Toggle: the toggle-root property</a>
 Toggle Concepts</a> <a href="#ref-for-list①">(2)</a> <a href="#ref-for-list②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string">
-   <a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-string">2. 
-Toggle Concepts</a> <a href="#ref-for-string①">(2)</a> <a href="#ref-for-string②">(3)</a> <a href="#ref-for-string③">(4)</a> <a href="#ref-for-string④">(5)</a> <a href="#ref-for-string⑤">(6)</a> <a href="#ref-for-string⑥">(7)</a> <a href="#ref-for-string⑦">(8)</a>
-   </ul>
-  </aside>
   <aside class="dfn-panel" data-for="term-for-struct">
    <a href="https://infra.spec.whatwg.org/#struct">https://infra.spec.whatwg.org/#struct</a><b>Referenced in:</b>
    <ul>
@@ -1964,6 +2058,13 @@ Introduction</a>
 Selecting Elements Based on Toggle State: the :toggle() pseudo-class</a>
    </ul>
   </aside>
+  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
+   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-idl-DOMString">6. 
+Scripting API</a> <a href="#ref-for-idl-DOMString①">(2)</a>
+   </ul>
+  </aside>
   <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
   <ul class="index">
    <li>
@@ -1976,18 +2077,16 @@ Selecting Elements Based on Toggle State: the :toggle() pseudo-class</a>
    <li>
     <a data-link-type="biblio">[css-display-3]</a> defines the following terms:
     <ul>
-     <li><span class="dfn-paneled" id="term-for-box">box</span>
      <li><span class="dfn-paneled" id="term-for-propdef-display">display</span>
      <li><span class="dfn-paneled" id="term-for-elements">element</span>
-     <li><span class="dfn-paneled" id="term-for-text-run">text run</span>
     </ul>
    <li>
     <a data-link-type="biblio">[css-values-4]</a> defines the following terms:
     <ul>
      <li><span class="dfn-paneled" id="term-for-mult-comma">#</span>
+     <li><span class="dfn-paneled" id="term-for-mult-zero-plus">*</span>
      <li><span class="dfn-paneled" id="term-for-identifier-value">&lt;custom-ident></span>
      <li><span class="dfn-paneled" id="term-for-integer-value">&lt;integer></span>
-     <li><span class="dfn-paneled" id="term-for-string-value">&lt;string></span>
      <li><span class="dfn-paneled" id="term-for-mult-opt">?</span>
      <li><span class="dfn-paneled" id="term-for-comb-one">|</span>
      <li><span class="dfn-paneled" id="term-for-comb-any">||</span>
@@ -1995,6 +2094,7 @@ Selecting Elements Based on Toggle State: the :toggle() pseudo-class</a>
    <li>
     <a data-link-type="biblio">[DOM]</a> defines the following terms:
     <ul>
+     <li><span class="dfn-paneled" id="term-for-element">Element</span>
      <li><span class="dfn-paneled" id="term-for-concept-tree-descendant">descendant</span>
      <li><span class="dfn-paneled" id="term-for-concept-tree-following">following</span>
      <li><span class="dfn-paneled" id="term-for-concept-tree-parent">parent</span>
@@ -2014,16 +2114,20 @@ Selecting Elements Based on Toggle State: the :toggle() pseudo-class</a>
     <a data-link-type="biblio">[INFRA]</a> defines the following terms:
     <ul>
      <li><span class="dfn-paneled" id="term-for-boolean">boolean</span>
-     <li><span class="dfn-paneled" id="term-for-string-is">identical to</span>
+     <li><span class="dfn-paneled" id="term-for-map-entry">entry</span>
      <li><span class="dfn-paneled" id="term-for-struct-item">item</span>
      <li><span class="dfn-paneled" id="term-for-list">list</span>
-     <li><span class="dfn-paneled" id="term-for-string">string</span>
      <li><span class="dfn-paneled" id="term-for-struct">struct</span>
     </ul>
    <li>
     <a data-link-type="biblio">[SELECTORS-4]</a> defines the following terms:
     <ul>
      <li><span class="dfn-paneled" id="term-for-checked-pseudo">:checked</span>
+    </ul>
+   <li>
+    <a data-link-type="biblio">[WEBIDL]</a> defines the following terms:
+    <ul>
+     <li><span class="dfn-paneled" id="term-for-idl-DOMString">DOMString</span>
     </ul>
   </ul>
   <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
@@ -2045,6 +2149,8 @@ Selecting Elements Based on Toggle State: the :toggle() pseudo-class</a>
    <dd>S. Bradner. <a href="https://datatracker.ietf.org/doc/html/rfc2119"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a>. March 1997. Best Current Practice. URL: <a href="https://datatracker.ietf.org/doc/html/rfc2119">https://datatracker.ietf.org/doc/html/rfc2119</a>
    <dt id="biblio-selectors-4">[SELECTORS-4]
    <dd>Elika Etemad; Tab Atkins Jr.. <a href="https://www.w3.org/TR/selectors-4/"><cite>Selectors Level 4</cite></a>. 21 November 2018. WD. URL: <a href="https://www.w3.org/TR/selectors-4/">https://www.w3.org/TR/selectors-4/</a>
+   <dt id="biblio-webidl">[WEBIDL]
+   <dd>Edgar Chen; Timothy Gu. <a href="https://webidl.spec.whatwg.org/"><cite>Web IDL Standard</cite></a>. Living Standard. URL: <a href="https://webidl.spec.whatwg.org/">https://webidl.spec.whatwg.org/</a>
   </dl>
   <h2 class="no-num no-ref heading settled" id="property-index"><span class="content">Property Index</span><a class="self-link" href="#property-index"></a></h2>
   <div class="big-element-wrapper">
@@ -2077,7 +2183,7 @@ Selecting Elements Based on Toggle State: the :toggle() pseudo-class</a>
       <td>
      <tr>
       <th scope="row"><a class="css" data-link-type="property" href="#propdef-toggle-group" id="ref-for-propdef-toggle-group④">toggle-group</a>
-      <td>none | [ &lt;toggle-name> self? ]#
+      <td>none | [ &lt;custom-ident> self? ]#
       <td>none
       <td>all elements
       <td>no
@@ -2088,7 +2194,7 @@ Selecting Elements Based on Toggle State: the :toggle() pseudo-class</a>
       <td>as specified
       <td>interactive
      <tr>
-      <th scope="row"><a class="css" data-link-type="property" href="#propdef-toggle-root" id="ref-for-propdef-toggle-root①②">toggle-root</a>
+      <th scope="row"><a class="css" data-link-type="property" href="#propdef-toggle-root" id="ref-for-propdef-toggle-root①①">toggle-root</a>
       <td>none | &lt;toggle-specifier>#
       <td>none
       <td>all elements
@@ -2101,7 +2207,7 @@ Selecting Elements Based on Toggle State: the :toggle() pseudo-class</a>
       <td>interactive
      <tr>
       <th scope="row"><a class="css" data-link-type="property" href="#propdef-toggle-trigger" id="ref-for-propdef-toggle-trigger⑧">toggle-trigger</a>
-      <td>none | [ &lt;toggle-name> &lt;integer [0,∞]>? ]#
+      <td>none | &lt;toggle-trigger>#
       <td>none
       <td>elements without existing activation behavior (see prose)
       <td>no
@@ -2113,7 +2219,7 @@ Selecting Elements Based on Toggle State: the :toggle() pseudo-class</a>
       <td>interactive
      <tr>
       <th scope="row"><a class="css" data-link-type="property" href="#propdef-toggle-visibility" id="ref-for-propdef-toggle-visibility④">toggle-visibility</a>
-      <td>normal | toggle &lt;toggle-name>
+      <td>normal | toggle &lt;custom-ident>
       <td>normal
       <td>all elements
       <td>no
@@ -2125,13 +2231,50 @@ Selecting Elements Based on Toggle State: the :toggle() pseudo-class</a>
       <td>
    </table>
   </div>
+  <h2 class="no-num no-ref heading settled" id="idl-index"><span class="content">IDL Index</span><a class="self-link" href="#idl-index"></a></h2>
+<pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="https://dom.spec.whatwg.org/#element"><c- g>Element</c-></a> {
+  <c- b>attribute</c-> <a data-link-type="idl-name" href="#csstogglemap"><c- n>CSSToggleMap</c-></a> <a data-type="CSSToggleMap" href="#dom-element-toggles"><code><c- g>toggles</c-></code></a>;
+};
+
+<c- b>interface</c-> <a href="#csstogglemap"><code><c- g>CSSToggleMap</c-></code></a> {
+  <c- b>maplike</c->&lt;<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-DOMString"><c- b>DOMString</c-></a>, <a data-link-type="idl-name" href="#csstoggle"><c- n>CSSToggle</c-></a>>;
+
+  <a data-link-type="idl-name" href="#csstogglemap"><c- n>CSSToggleMap</c-></a> <a href="#dom-csstogglemap-set"><code><c- g>set</c-></code></a>(<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-DOMString"><c- b>DOMString</c-></a> <a href="#dom-csstogglemap-set-name-options-name"><code><c- g>name</c-></code></a>, <a data-link-type="idl-name" href="#dictdef-csstoggledata"><c- n>CSSToggleData</c-></a> <a href="#dom-csstogglemap-set-name-options-options"><code><c- g>options</c-></code></a>);
+};
+
+<c- b>interface</c-> <a href="#csstoggle"><code><c- g>CSSToggle</c-></code></a> {
+  <c- b>attribute</c-> <a data-link-type="idl-name"><c- n>int</c-></a> <a data-type="int" href="#dom-csstoggle-value"><code><c- g>value</c-></code></a>;
+  <c- b>attribute</c-> <a data-link-type="idl-name"><c- n>int</c-></a> <a data-type="int" href="#dom-csstoggle-maximum"><code><c- g>maximum</c-></code></a>;
+  <c- b>attribute</c-> <a data-link-type="idl-name"><c- n>bool</c-></a> <a data-type="bool" href="#dom-csstoggle-group"><code><c- g>group</c-></code></a>;
+  <c- b>attribute</c-> <a data-link-type="idl-name" href="#enumdef-csstogglescope"><c- n>CSSToggleScope</c-></a> <a data-type="CSSToggleScope" href="#dom-csstoggle-scope"><code><c- g>scope</c-></code></a>;
+  <c- b>attribute</c-> <a data-link-type="idl-name" href="#enumdef-csstogglecycle"><c- n>CSSToggleCycle</c-></a> <a data-type="CSSToggleCycle" href="#dom-csstoggle-cycle"><code><c- g>cycle</c-></code></a>;
+
+  <a href="#dom-csstoggle-csstoggle"><code><c- g>constructor</c-></code></a>(<a data-link-type="idl-name" href="#dictdef-csstoggledata"><c- n>CSSToggleData</c-></a> <a href="#dom-csstoggle-csstoggle-options-options"><code><c- g>options</c-></code></a>);
+};
+
+<c- b>dictionary</c-> <a href="#dictdef-csstoggledata"><code><c- g>CSSToggleData</c-></code></a> {
+  <a data-link-type="idl-name"><c- n>int</c-></a> <a data-type="int " href="#dom-csstoggledata-value"><code><c- g>value</c-></code></a>;
+  <a data-link-type="idl-name"><c- n>int</c-></a> <a data-type="int " href="#dom-csstoggledata-maximum"><code><c- g>maximum</c-></code></a>;
+  <a data-link-type="idl-name"><c- n>bool</c-></a> <a data-type="bool " href="#dom-csstoggledata-group"><code><c- g>group</c-></code></a>;
+  <a data-link-type="idl-name" href="#enumdef-csstogglescope"><c- n>CSSToggleScope</c-></a> <a data-type="CSSToggleScope " href="#dom-csstoggledata-scope"><code><c- g>scope</c-></code></a>;
+  <a data-link-type="idl-name" href="#enumdef-csstogglecycle"><c- n>CSSToggleCycle</c-></a> <a data-type="CSSToggleCycle " href="#dom-csstoggledata-cycle"><code><c- g>cycle</c-></code></a>;
+};
+
+<c- b>enum</c-> <a href="#enumdef-csstogglescope"><code><c- g>CSSToggleScope</c-></code></a> {
+  <a href="#dom-csstogglescope-narrow"><code><c- s>"narrow"</c-></code></a>,
+  <a href="#dom-csstogglescope-wide"><code><c- s>"wide"</c-></code></a>,
+};
+
+<c- b>enum</c-> <a href="#enumdef-csstogglecycle"><code><c- g>CSSToggleCycle</c-></code></a> {
+  <a href="#dom-csstogglecycle-cycle"><code><c- s>"cycle"</c-></code></a>,
+  <a href="#dom-csstogglecycle-cycle-on"><code><c- s>"cycle-on"</c-></code></a>,
+}
+
+</pre>
   <h2 class="no-num no-ref heading settled" id="issues-index"><span class="content">Issues Index</span><a class="self-link" href="#issues-index"></a></h2>
   <div style="counter-reset:issue">
-   <div class="issue"> TODO create the <span class="css">toggle-states</span> property
-	that defines <a data-link-type="dfn" href="#toggle-state-names">state names</a> for a <a data-link-type="dfn" href="#css-toggle">toggle</a>,
-	and amend the various properties to allow them to take a <a class="production css" data-link-type="type" href="#typedef-toggle-toggle-name">&lt;toggle-name></a> instead of an <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#integer-value">&lt;integer></a>. <a class="issue-return" href="#issue-80e16e8c" title="Jump to section">↵</a></div>
    <div class="issue"> Define the precise point in <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering">update the rendering</a> when toggles are created
-	if <a class="property css" data-link-type="property" href="#propdef-toggle-root">toggle-root</a> names a toggle that doesn’t exist on the element yet. <a class="issue-return" href="#issue-f7fd1228" title="Jump to section">↵</a></div>
+	if <a class="property" data-link-type="propdesc" href="#propdef-toggle-root">toggle-root</a> names a toggle that doesn’t exist on the element yet. <a class="issue-return" href="#issue-f7fd1228" title="Jump to section">↵</a></div>
    <div class="issue">
      Radio buttons have one particular tabbing/switching/activation behavior
 		(they occupy a single tabindex spot;
@@ -2145,6 +2288,11 @@ Selecting Elements Based on Toggle State: the :toggle() pseudo-class</a>
 		are there more than these two behaviors to deal with?</p>
      <a class="issue-return" href="#issue-47da3fb8" title="Jump to section">↵</a>
    </div>
+   <div class="issue"> Consider adding support for an at-rule that defines machine states,
+	the available events to trigger from each state,
+	and the resulting state of each event.
+	In that case <a class="production css" data-link-type="type" href="#typedef-trigger-action">&lt;trigger-action></a> would need to also accept custom events,
+	possibly marked by a new keyword or function. <a class="issue-return" href="#issue-b8bd39f2" title="Jump to section">↵</a></div>
    <div class="issue"> Define in much greater precision what it means to "become activatable".
 	The element must become focusable
 	(with a default spot in the focus order)
@@ -2157,152 +2305,119 @@ Selecting Elements Based on Toggle State: the :toggle() pseudo-class</a>
      TODO 
     <ul>
      <li data-md>
-      <p>a <a class="property css" data-link-type="property" href="#propdef-toggle-trigger">toggle-trigger</a> element needs to become activatable/focusable/etc,
+      <p>a <a class="property" data-link-type="propdesc" href="#propdef-toggle-trigger">toggle-trigger</a> element needs to become activatable/focusable/etc,
 and communicate in the a11y tree that it’s a checkbox/radio/etc</p>
      <li data-md>
       <p>we can infer what type of control it is
 by examining the properties of the toggle:
-if it’s part of a group, sticky, etc.</p>
+if it’s part of a group, cycle-on, etc.</p>
      <li data-md>
-      <p>if <a class="property css" data-link-type="property" href="#propdef-toggle-visibility">toggle-visibility</a> is in use,
+      <p>if <a class="property" data-link-type="propdesc" href="#propdef-toggle-visibility">toggle-visibility</a> is in use,
 we can also automatically infer all the tab-set ARIA roles</p>
     </ul>
-     <a class="issue-return" href="#issue-d75619e8" title="Jump to section">↵</a>
+     <a class="issue-return" href="#issue-55ec88b3" title="Jump to section">↵</a>
    </div>
    <div class="issue"> Define ordering of activations,
 	so if multiple elements become relevant at the same time
 	and they’re all part of a <a data-link-type="dfn" href="#css-toggle-group">toggle group</a>,
 	which one "wins" is well-defined. <a class="issue-return" href="#issue-8c43f943" title="Jump to section">↵</a></div>
-   <div class="issue">
-     TODO 
-    <ul>
-     <li data-md>
-      <p>Expose a map of toggles on an element, with {name=>rest of <a data-link-type="dfn" href="#css-toggle">toggle</a> info}.
-(Or just a list of toggles, with name built into the object?)</p>
-     <li data-md>
-      <p>Ability to create toggles manually.
-(Tho without an accompanying <a class="property css" data-link-type="property" href="#propdef-toggle-root">toggle-root</a>,
-you just get the <a data-link-type="dfn" href="#default-toggle-specifier">default toggle specifier</a> when it’s activated.)</p>
-     <li data-md>
-      <p>Ability to delete toggles manually.
-(Tho if you don’t remove the accompanying <a class="property css" data-link-type="property" href="#propdef-toggle-root">toggle-root</a>,
-it’ll respawn on the next rendering tick.)</p>
-     <li data-md>
-      <p>Ability to set toggle state manually.</p>
-    </ul>
-     <a class="issue-return" href="#issue-adf5ca30" title="Jump to section">↵</a>
-   </div>
   </div>
   <aside class="dfn-panel" data-for="toggle-root">
    <b><a href="#toggle-root">#toggle-root</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-toggle-root">1. 
-Introduction</a>
+    <li><a href="#ref-for-toggle-root">1.1. Terminology</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="css-toggle">
    <b><a href="#css-toggle">#css-toggle</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-css-toggle">1. 
-Introduction</a> <a href="#ref-for-css-toggle①">(2)</a> <a href="#ref-for-css-toggle②">(3)</a>
-    <li><a href="#ref-for-css-toggle③">2. 
-Toggle Concepts</a> <a href="#ref-for-css-toggle④">(2)</a> <a href="#ref-for-css-toggle⑤">(3)</a> <a href="#ref-for-css-toggle⑥">(4)</a> <a href="#ref-for-css-toggle⑦">(5)</a> <a href="#ref-for-css-toggle⑧">(6)</a> <a href="#ref-for-css-toggle⑨">(7)</a> <a href="#ref-for-css-toggle①⓪">(8)</a> <a href="#ref-for-css-toggle①①">(9)</a> <a href="#ref-for-css-toggle①②">(10)</a> <a href="#ref-for-css-toggle①③">(11)</a> <a href="#ref-for-css-toggle①④">(12)</a> <a href="#ref-for-css-toggle①⑤">(13)</a> <a href="#ref-for-css-toggle①⑥">(14)</a> <a href="#ref-for-css-toggle①⑦">(15)</a> <a href="#ref-for-css-toggle①⑧">(16)</a> <a href="#ref-for-css-toggle①⑨">(17)</a> <a href="#ref-for-css-toggle②⓪">(18)</a> <a href="#ref-for-css-toggle②①">(19)</a> <a href="#ref-for-css-toggle②②">(20)</a> <a href="#ref-for-css-toggle②③">(21)</a> <a href="#ref-for-css-toggle②④">(22)</a>
-    <li><a href="#ref-for-css-toggle②⑤">2.1. 
+    <li><a href="#ref-for-css-toggle">1.1. Terminology</a> <a href="#ref-for-css-toggle①">(2)</a> <a href="#ref-for-css-toggle②">(3)</a> <a href="#ref-for-css-toggle③">(4)</a>
+    <li><a href="#ref-for-css-toggle④">2. 
+Toggle Concepts</a> <a href="#ref-for-css-toggle⑤">(2)</a> <a href="#ref-for-css-toggle⑥">(3)</a> <a href="#ref-for-css-toggle⑦">(4)</a> <a href="#ref-for-css-toggle⑧">(5)</a> <a href="#ref-for-css-toggle⑨">(6)</a> <a href="#ref-for-css-toggle①⓪">(7)</a> <a href="#ref-for-css-toggle①①">(8)</a> <a href="#ref-for-css-toggle①②">(9)</a> <a href="#ref-for-css-toggle①③">(10)</a> <a href="#ref-for-css-toggle①④">(11)</a> <a href="#ref-for-css-toggle①⑤">(12)</a> <a href="#ref-for-css-toggle①⑥">(13)</a> <a href="#ref-for-css-toggle①⑦">(14)</a> <a href="#ref-for-css-toggle①⑧">(15)</a> <a href="#ref-for-css-toggle①⑨">(16)</a> <a href="#ref-for-css-toggle②⓪">(17)</a> <a href="#ref-for-css-toggle②①">(18)</a> <a href="#ref-for-css-toggle②②">(19)</a> <a href="#ref-for-css-toggle②③">(20)</a> <a href="#ref-for-css-toggle②④">(21)</a> <a href="#ref-for-css-toggle②⑤">(22)</a>
+    <li><a href="#ref-for-css-toggle②⑥">2.1. 
 Toggles and CSS Properties</a>
-    <li><a href="#ref-for-css-toggle②⑥">3. 
-Creating a Toggle: the toggle-root property</a> <a href="#ref-for-css-toggle②⑦">(2)</a> <a href="#ref-for-css-toggle②⑧">(3)</a> <a href="#ref-for-css-toggle②⑨">(4)</a>
+    <li><a href="#ref-for-css-toggle②⑦">3. 
+Creating a Toggle: the toggle-root property</a> <a href="#ref-for-css-toggle②⑧">(2)</a> <a href="#ref-for-css-toggle②⑨">(3)</a>
     <li><a href="#ref-for-css-toggle③⓪">3.1. 
-Linking Toggle States: the toggle-group property</a> <a href="#ref-for-css-toggle③①">(2)</a> <a href="#ref-for-css-toggle③②">(3)</a> <a href="#ref-for-css-toggle③③">(4)</a> <a href="#ref-for-css-toggle③④">(5)</a> <a href="#ref-for-css-toggle③⑤">(6)</a>
-    <li><a href="#ref-for-css-toggle③⑥">3.2. 
-Activating a Toggle: the toggle-trigger property</a> <a href="#ref-for-css-toggle③⑦">(2)</a> <a href="#ref-for-css-toggle③⑧">(3)</a> <a href="#ref-for-css-toggle③⑨">(4)</a> <a href="#ref-for-css-toggle④⓪">(5)</a> <a href="#ref-for-css-toggle④①">(6)</a> <a href="#ref-for-css-toggle④②">(7)</a> <a href="#ref-for-css-toggle④③">(8)</a> <a href="#ref-for-css-toggle④④">(9)</a> <a href="#ref-for-css-toggle④⑤">(10)</a>
-    <li><a href="#ref-for-css-toggle④⑥">3.3. 
-Creating and Activating Toggles Simultaneously: the toggle shorthand</a> <a href="#ref-for-css-toggle④⑦">(2)</a> <a href="#ref-for-css-toggle④⑧">(3)</a>
-    <li><a href="#ref-for-css-toggle④⑨">4. 
-Selecting Elements Based on Toggle State: the :toggle() pseudo-class</a> <a href="#ref-for-css-toggle⑤⓪">(2)</a> <a href="#ref-for-css-toggle⑤①">(3)</a> <a href="#ref-for-css-toggle⑤②">(4)</a> <a href="#ref-for-css-toggle⑤③">(5)</a> <a href="#ref-for-css-toggle⑤④">(6)</a>
-    <li><a href="#ref-for-css-toggle⑤⑤">5. 
-Automatically Hiding With A Toggle</a> <a href="#ref-for-css-toggle⑤⑥">(2)</a> <a href="#ref-for-css-toggle⑤⑦">(3)</a> <a href="#ref-for-css-toggle⑤⑧">(4)</a> <a href="#ref-for-css-toggle⑤⑨">(5)</a> <a href="#ref-for-css-toggle⑥⓪">(6)</a> <a href="#ref-for-css-toggle⑥①">(7)</a> <a href="#ref-for-css-toggle⑥②">(8)</a> <a href="#ref-for-css-toggle⑥③">(9)</a> <a href="#ref-for-css-toggle⑥④">(10)</a>
-    <li><a href="#ref-for-css-toggle⑥⑤">6. 
-Scripting API</a>
+Toggle Creation Details</a>
+    <li><a href="#ref-for-css-toggle③①">3.2. 
+Linking Toggle States: the toggle-group property</a> <a href="#ref-for-css-toggle③②">(2)</a> <a href="#ref-for-css-toggle③③">(3)</a> <a href="#ref-for-css-toggle③④">(4)</a> <a href="#ref-for-css-toggle③⑤">(5)</a> <a href="#ref-for-css-toggle③⑥">(6)</a>
+    <li><a href="#ref-for-css-toggle③⑦">3.3. 
+Activating a Toggle: the toggle-trigger property</a> <a href="#ref-for-css-toggle③⑧">(2)</a> <a href="#ref-for-css-toggle③⑨">(3)</a> <a href="#ref-for-css-toggle④⓪">(4)</a> <a href="#ref-for-css-toggle④①">(5)</a> <a href="#ref-for-css-toggle④②">(6)</a> <a href="#ref-for-css-toggle④③">(7)</a> <a href="#ref-for-css-toggle④④">(8)</a> <a href="#ref-for-css-toggle④⑤">(9)</a> <a href="#ref-for-css-toggle④⑥">(10)</a> <a href="#ref-for-css-toggle④⑦">(11)</a>
+    <li><a href="#ref-for-css-toggle④⑧">3.4. 
+Creating and Activating Toggles Simultaneously: the toggle shorthand</a> <a href="#ref-for-css-toggle④⑨">(2)</a> <a href="#ref-for-css-toggle⑤⓪">(3)</a>
+    <li><a href="#ref-for-css-toggle⑤①">4. 
+Selecting Elements Based on Toggle State: the :toggle() pseudo-class</a> <a href="#ref-for-css-toggle⑤②">(2)</a> <a href="#ref-for-css-toggle⑤③">(3)</a> <a href="#ref-for-css-toggle⑤④">(4)</a> <a href="#ref-for-css-toggle⑤⑤">(5)</a> <a href="#ref-for-css-toggle⑤⑥">(6)</a>
+    <li><a href="#ref-for-css-toggle⑤⑦">5. 
+Automatically Hiding With A Toggle</a> <a href="#ref-for-css-toggle⑤⑧">(2)</a> <a href="#ref-for-css-toggle⑤⑨">(3)</a> <a href="#ref-for-css-toggle⑥⓪">(4)</a> <a href="#ref-for-css-toggle⑥①">(5)</a> <a href="#ref-for-css-toggle⑥②">(6)</a> <a href="#ref-for-css-toggle⑥③">(7)</a> <a href="#ref-for-css-toggle⑥④">(8)</a> <a href="#ref-for-css-toggle⑥⑤">(9)</a>
+    <li><a href="#ref-for-css-toggle⑥⑥">6. 
+Scripting API</a> <a href="#ref-for-css-toggle⑥⑦">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="toggle-name">
    <b><a href="#toggle-name">#toggle-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-toggle-name">2. 
-Toggle Concepts</a> <a href="#ref-for-toggle-name①">(2)</a> <a href="#ref-for-toggle-name②">(3)</a> <a href="#ref-for-toggle-name③">(4)</a> <a href="#ref-for-toggle-name④">(5)</a> <a href="#ref-for-toggle-name⑤">(6)</a> <a href="#ref-for-toggle-name⑥">(7)</a> <a href="#ref-for-toggle-name⑦">(8)</a> <a href="#ref-for-toggle-name⑧">(9)</a>
-    <li><a href="#ref-for-toggle-name⑨">3.1. 
+Toggle Concepts</a> <a href="#ref-for-toggle-name①">(2)</a> <a href="#ref-for-toggle-name②">(3)</a> <a href="#ref-for-toggle-name③">(4)</a> <a href="#ref-for-toggle-name④">(5)</a> <a href="#ref-for-toggle-name⑤">(6)</a>
+    <li><a href="#ref-for-toggle-name⑥">3.2. 
 Linking Toggle States: the toggle-group property</a>
-    <li><a href="#ref-for-toggle-name①⓪">3.2. 
-Activating a Toggle: the toggle-trigger property</a> <a href="#ref-for-toggle-name①①">(2)</a>
-    <li><a href="#ref-for-toggle-name①②">4. 
+    <li><a href="#ref-for-toggle-name⑦">3.3. 
+Activating a Toggle: the toggle-trigger property</a> <a href="#ref-for-toggle-name⑧">(2)</a>
+    <li><a href="#ref-for-toggle-name⑨">4. 
 Selecting Elements Based on Toggle State: the :toggle() pseudo-class</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="typedef-toggle-toggle-name">
-   <b><a href="#typedef-toggle-toggle-name">#typedef-toggle-toggle-name</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-typedef-toggle-toggle-name">2. 
-Toggle Concepts</a> <a href="#ref-for-typedef-toggle-toggle-name①">(2)</a> <a href="#ref-for-typedef-toggle-toggle-name②">(3)</a> <a href="#ref-for-typedef-toggle-toggle-name③">(4)</a>
-    <li><a href="#ref-for-typedef-toggle-toggle-name④">3. 
-Creating a Toggle: the toggle-root property</a> <a href="#ref-for-typedef-toggle-toggle-name⑤">(2)</a> <a href="#ref-for-typedef-toggle-toggle-name⑥">(3)</a>
-    <li><a href="#ref-for-typedef-toggle-toggle-name⑦">3.1. 
-Linking Toggle States: the toggle-group property</a> <a href="#ref-for-typedef-toggle-toggle-name⑧">(2)</a> <a href="#ref-for-typedef-toggle-toggle-name⑨">(3)</a>
-    <li><a href="#ref-for-typedef-toggle-toggle-name①⓪">3.2. 
-Activating a Toggle: the toggle-trigger property</a> <a href="#ref-for-typedef-toggle-toggle-name①①">(2)</a> <a href="#ref-for-typedef-toggle-toggle-name①②">(3)</a>
-    <li><a href="#ref-for-typedef-toggle-toggle-name①③">3.3. 
-Creating and Activating Toggles Simultaneously: the toggle shorthand</a>
-    <li><a href="#ref-for-typedef-toggle-toggle-name①④">4. 
-Selecting Elements Based on Toggle State: the :toggle() pseudo-class</a> <a href="#ref-for-typedef-toggle-toggle-name①⑤">(2)</a>
-    <li><a href="#ref-for-typedef-toggle-toggle-name①⑥">5. 
-Automatically Hiding With A Toggle</a> <a href="#ref-for-typedef-toggle-toggle-name①⑦">(2)</a> <a href="#ref-for-typedef-toggle-toggle-name①⑧">(3)</a> <a href="#ref-for-typedef-toggle-toggle-name①⑨">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="toggle-state">
    <b><a href="#toggle-state">#toggle-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-toggle-state">2. 
-Toggle Concepts</a> <a href="#ref-for-toggle-state①">(2)</a>
-    <li><a href="#ref-for-toggle-state②">3.1. 
-Linking Toggle States: the toggle-group property</a> <a href="#ref-for-toggle-state③">(2)</a> <a href="#ref-for-toggle-state④">(3)</a> <a href="#ref-for-toggle-state⑤">(4)</a>
-    <li><a href="#ref-for-toggle-state⑥">3.2. 
-Activating a Toggle: the toggle-trigger property</a> <a href="#ref-for-toggle-state⑦">(2)</a> <a href="#ref-for-toggle-state⑧">(3)</a> <a href="#ref-for-toggle-state⑨">(4)</a> <a href="#ref-for-toggle-state①⓪">(5)</a> <a href="#ref-for-toggle-state①①">(6)</a> <a href="#ref-for-toggle-state①②">(7)</a> <a href="#ref-for-toggle-state①③">(8)</a>
-    <li><a href="#ref-for-toggle-state①④">4. 
-Selecting Elements Based on Toggle State: the :toggle() pseudo-class</a> <a href="#ref-for-toggle-state①⑤">(2)</a>
+Toggle Concepts</a> <a href="#ref-for-toggle-state①">(2)</a> <a href="#ref-for-toggle-state②">(3)</a> <a href="#ref-for-toggle-state③">(4)</a> <a href="#ref-for-toggle-state④">(5)</a> <a href="#ref-for-toggle-state⑤">(6)</a> <a href="#ref-for-toggle-state⑥">(7)</a> <a href="#ref-for-toggle-state⑦">(8)</a> <a href="#ref-for-toggle-state⑧">(9)</a>
+    <li><a href="#ref-for-toggle-state⑨">3.2. 
+Linking Toggle States: the toggle-group property</a> <a href="#ref-for-toggle-state①⓪">(2)</a> <a href="#ref-for-toggle-state①①">(3)</a> <a href="#ref-for-toggle-state①②">(4)</a>
+    <li><a href="#ref-for-toggle-state①③">3.3. 
+Activating a Toggle: the toggle-trigger property</a> <a href="#ref-for-toggle-state①④">(2)</a> <a href="#ref-for-toggle-state①⑤">(3)</a> <a href="#ref-for-toggle-state①⑥">(4)</a> <a href="#ref-for-toggle-state①⑦">(5)</a> <a href="#ref-for-toggle-state①⑧">(6)</a>
+    <li><a href="#ref-for-toggle-state①⑨">4. 
+Selecting Elements Based on Toggle State: the :toggle() pseudo-class</a> <a href="#ref-for-toggle-state②⓪">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="toggle-inactive-state">
    <b><a href="#toggle-inactive-state">#toggle-inactive-state</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-toggle-inactive-state">2. 
-Toggle Concepts</a>
-    <li><a href="#ref-for-toggle-inactive-state①">2.1. 
+    <li><a href="#ref-for-toggle-inactive-state">2.1. 
 Toggles and CSS Properties</a>
-    <li><a href="#ref-for-toggle-inactive-state②">4. 
-Selecting Elements Based on Toggle State: the :toggle() pseudo-class</a> <a href="#ref-for-toggle-inactive-state③">(2)</a>
-    <li><a href="#ref-for-toggle-inactive-state④">5. 
-Automatically Hiding With A Toggle</a> <a href="#ref-for-toggle-inactive-state⑤">(2)</a> <a href="#ref-for-toggle-inactive-state⑥">(3)</a>
+    <li><a href="#ref-for-toggle-inactive-state①">4. 
+Selecting Elements Based on Toggle State: the :toggle() pseudo-class</a> <a href="#ref-for-toggle-inactive-state②">(2)</a>
+    <li><a href="#ref-for-toggle-inactive-state③">5. 
+Automatically Hiding With A Toggle</a> <a href="#ref-for-toggle-inactive-state④">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="toggle-active-state">
    <b><a href="#toggle-active-state">#toggle-active-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-toggle-active-state">2. 
-Toggle Concepts</a> <a href="#ref-for-toggle-active-state①">(2)</a> <a href="#ref-for-toggle-active-state②">(3)</a>
-    <li><a href="#ref-for-toggle-active-state③">2.1. 
+Toggle Concepts</a> <a href="#ref-for-toggle-active-state①">(2)</a>
+    <li><a href="#ref-for-toggle-active-state②">2.1. 
 Toggles and CSS Properties</a>
-    <li><a href="#ref-for-toggle-active-state④">3.1. 
-Linking Toggle States: the toggle-group property</a> <a href="#ref-for-toggle-active-state⑤">(2)</a>
-    <li><a href="#ref-for-toggle-active-state⑥">4. 
+    <li><a href="#ref-for-toggle-active-state③">3.2. 
+Linking Toggle States: the toggle-group property</a> <a href="#ref-for-toggle-active-state④">(2)</a>
+    <li><a href="#ref-for-toggle-active-state⑤">4. 
 Selecting Elements Based on Toggle State: the :toggle() pseudo-class</a>
-    <li><a href="#ref-for-toggle-active-state⑦">5. 
+    <li><a href="#ref-for-toggle-active-state⑥">5. 
 Automatically Hiding With A Toggle</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="toggle-match-state">
+   <b><a href="#toggle-match-state">#toggle-match-state</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-toggle-match-state">4. 
+Selecting Elements Based on Toggle State: the :toggle() pseudo-class</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="toggle-state-names">
    <b><a href="#toggle-state-names">#toggle-state-names</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-toggle-state-names">3. 
-Creating a Toggle: the toggle-root property</a>
+    <li><a href="#ref-for-toggle-state-names">2. 
+Toggle Concepts</a> <a href="#ref-for-toggle-state-names①">(2)</a> <a href="#ref-for-toggle-state-names②">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="toggle-group">
@@ -2319,7 +2434,7 @@ Toggle Concepts</a> <a href="#ref-for-toggle-group①">(2)</a>
 Toggle Concepts</a> <a href="#ref-for-toggle-scope①">(2)</a> <a href="#ref-for-toggle-scope②">(3)</a>
     <li><a href="#ref-for-toggle-scope③">2.1. 
 Toggles and CSS Properties</a>
-    <li><a href="#ref-for-toggle-scope④">3.3. 
+    <li><a href="#ref-for-toggle-scope④">3.4. 
 Creating and Activating Toggles Simultaneously: the toggle shorthand</a>
    </ul>
   </aside>
@@ -2328,9 +2443,9 @@ Creating and Activating Toggles Simultaneously: the toggle shorthand</a>
    <ul>
     <li><a href="#ref-for-css-toggle-group">2. 
 Toggle Concepts</a> <a href="#ref-for-css-toggle-group①">(2)</a> <a href="#ref-for-css-toggle-group②">(3)</a> <a href="#ref-for-css-toggle-group③">(4)</a> <a href="#ref-for-css-toggle-group④">(5)</a> <a href="#ref-for-css-toggle-group⑤">(6)</a> <a href="#ref-for-css-toggle-group⑥">(7)</a> <a href="#ref-for-css-toggle-group⑦">(8)</a> <a href="#ref-for-css-toggle-group⑧">(9)</a> <a href="#ref-for-css-toggle-group⑨">(10)</a> <a href="#ref-for-css-toggle-group①⓪">(11)</a> <a href="#ref-for-css-toggle-group①①">(12)</a> <a href="#ref-for-css-toggle-group①②">(13)</a> <a href="#ref-for-css-toggle-group①③">(14)</a>
-    <li><a href="#ref-for-css-toggle-group①④">3.1. 
+    <li><a href="#ref-for-css-toggle-group①④">3.2. 
 Linking Toggle States: the toggle-group property</a> <a href="#ref-for-css-toggle-group①⑤">(2)</a> <a href="#ref-for-css-toggle-group①⑥">(3)</a> <a href="#ref-for-css-toggle-group①⑦">(4)</a>
-    <li><a href="#ref-for-css-toggle-group①⑧">3.2. 
+    <li><a href="#ref-for-css-toggle-group①⑧">3.3. 
 Activating a Toggle: the toggle-trigger property</a>
     <li><a href="#ref-for-css-toggle-group①⑨">5. 
 Automatically Hiding With A Toggle</a>
@@ -2339,23 +2454,23 @@ Automatically Hiding With A Toggle</a>
   <aside class="dfn-panel" data-for="toggle-group-name">
    <b><a href="#toggle-group-name">#toggle-group-name</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-toggle-group-name">3.1. 
+    <li><a href="#ref-for-toggle-group-name">3.2. 
 Linking Toggle States: the toggle-group property</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="toggle-group-scope">
    <b><a href="#toggle-group-scope">#toggle-group-scope</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-toggle-group-scope">3.1. 
+    <li><a href="#ref-for-toggle-group-scope">3.2. 
 Linking Toggle States: the toggle-group property</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="toggle-in-a-toggle-group">
    <b><a href="#toggle-in-a-toggle-group">#toggle-in-a-toggle-group</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-toggle-in-a-toggle-group">3.1. 
+    <li><a href="#ref-for-toggle-in-a-toggle-group">3.2. 
 Linking Toggle States: the toggle-group property</a>
-    <li><a href="#ref-for-toggle-in-a-toggle-group①">3.2. 
+    <li><a href="#ref-for-toggle-in-a-toggle-group①">3.3. 
 Activating a Toggle: the toggle-trigger property</a>
    </ul>
   </aside>
@@ -2378,9 +2493,9 @@ Toggle Concepts</a> <a href="#ref-for-toggle-narrow-scope①">(2)</a>
    <ul>
     <li><a href="#ref-for-toggle-in-scope">2. 
 Toggle Concepts</a> <a href="#ref-for-toggle-in-scope①">(2)</a>
-    <li><a href="#ref-for-toggle-in-scope②">3.1. 
+    <li><a href="#ref-for-toggle-in-scope②">3.2. 
 Linking Toggle States: the toggle-group property</a> <a href="#ref-for-toggle-in-scope③">(2)</a>
-    <li><a href="#ref-for-toggle-in-scope④">3.2. 
+    <li><a href="#ref-for-toggle-in-scope④">3.3. 
 Activating a Toggle: the toggle-trigger property</a>
     <li><a href="#ref-for-toggle-in-scope⑤">4. 
 Selecting Elements Based on Toggle State: the :toggle() pseudo-class</a>
@@ -2395,7 +2510,7 @@ Automatically Hiding With A Toggle</a>
 Toggle Concepts</a> <a href="#ref-for-toggle-toggle-specifier①">(2)</a> <a href="#ref-for-toggle-toggle-specifier②">(3)</a>
     <li><a href="#ref-for-toggle-toggle-specifier③">3. 
 Creating a Toggle: the toggle-root property</a> <a href="#ref-for-toggle-toggle-specifier④">(2)</a> <a href="#ref-for-toggle-toggle-specifier⑤">(3)</a>
-    <li><a href="#ref-for-toggle-toggle-specifier⑥">3.2. 
+    <li><a href="#ref-for-toggle-toggle-specifier⑥">3.3. 
 Activating a Toggle: the toggle-trigger property</a>
    </ul>
   </aside>
@@ -2406,7 +2521,7 @@ Activating a Toggle: the toggle-trigger property</a>
 Toggle Concepts</a>
     <li><a href="#ref-for-toggle-specifier-name①">3. 
 Creating a Toggle: the toggle-root property</a>
-    <li><a href="#ref-for-toggle-specifier-name②">3.2. 
+    <li><a href="#ref-for-toggle-specifier-name②">3.3. 
 Activating a Toggle: the toggle-trigger property</a>
    </ul>
   </aside>
@@ -2419,11 +2534,22 @@ Toggle Concepts</a>
 Creating a Toggle: the toggle-root property</a>
    </ul>
   </aside>
+  <aside class="dfn-panel" data-for="toggle-specifier-maximum-state">
+   <b><a href="#toggle-specifier-maximum-state">#toggle-specifier-maximum-state</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-toggle-specifier-maximum-state">2. 
+Toggle Concepts</a> <a href="#ref-for-toggle-specifier-maximum-state①">(2)</a> <a href="#ref-for-toggle-specifier-maximum-state②">(3)</a> <a href="#ref-for-toggle-specifier-maximum-state③">(4)</a> <a href="#ref-for-toggle-specifier-maximum-state④">(5)</a> <a href="#ref-for-toggle-specifier-maximum-state⑤">(6)</a> <a href="#ref-for-toggle-specifier-maximum-state⑥">(7)</a> <a href="#ref-for-toggle-specifier-maximum-state⑦">(8)</a>
+    <li><a href="#ref-for-toggle-specifier-maximum-state⑧">3. 
+Creating a Toggle: the toggle-root property</a> <a href="#ref-for-toggle-specifier-maximum-state⑨">(2)</a> <a href="#ref-for-toggle-specifier-maximum-state①⓪">(3)</a>
+   </ul>
+  </aside>
   <aside class="dfn-panel" data-for="toggle-specifier-state-names">
    <b><a href="#toggle-specifier-state-names">#toggle-specifier-state-names</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-toggle-specifier-state-names">2. 
-Toggle Concepts</a>
+Toggle Concepts</a> <a href="#ref-for-toggle-specifier-state-names①">(2)</a>
+    <li><a href="#ref-for-toggle-specifier-state-names②">3. 
+Creating a Toggle: the toggle-root property</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="toggle-specifier-group">
@@ -2444,52 +2570,38 @@ Toggle Concepts</a>
 Creating a Toggle: the toggle-root property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="toggle-specifier-maximum-state">
-   <b><a href="#toggle-specifier-maximum-state">#toggle-specifier-maximum-state</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="toggle-specifier-overflow">
+   <b><a href="#toggle-specifier-overflow">#toggle-specifier-overflow</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-toggle-specifier-maximum-state">2. 
-Toggle Concepts</a> <a href="#ref-for-toggle-specifier-maximum-state①">(2)</a>
-    <li><a href="#ref-for-toggle-specifier-maximum-state②">3. 
-Creating a Toggle: the toggle-root property</a>
-    <li><a href="#ref-for-toggle-specifier-maximum-state③">3.2. 
-Activating a Toggle: the toggle-trigger property</a> <a href="#ref-for-toggle-specifier-maximum-state④">(2)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="toggle-specifier-sticky">
-   <b><a href="#toggle-specifier-sticky">#toggle-specifier-sticky</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-toggle-specifier-sticky">2. 
+    <li><a href="#ref-for-toggle-specifier-overflow">2. 
 Toggle Concepts</a>
-    <li><a href="#ref-for-toggle-specifier-sticky①">3. 
+    <li><a href="#ref-for-toggle-specifier-overflow①">3. 
 Creating a Toggle: the toggle-root property</a>
-    <li><a href="#ref-for-toggle-specifier-sticky②">3.2. 
+    <li><a href="#ref-for-toggle-specifier-overflow②">3.3. 
 Activating a Toggle: the toggle-trigger property</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="default-toggle-specifier">
    <b><a href="#default-toggle-specifier">#default-toggle-specifier</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-default-toggle-specifier">3.2. 
+    <li><a href="#ref-for-default-toggle-specifier">3.3. 
 Activating a Toggle: the toggle-trigger property</a>
-    <li><a href="#ref-for-default-toggle-specifier①">6. 
-Scripting API</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="propdef-toggle-root">
    <b><a href="#propdef-toggle-root">#propdef-toggle-root</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-propdef-toggle-root">1. 
-Introduction</a>
+    <li><a href="#ref-for-propdef-toggle-root">1.1. Terminology</a>
     <li><a href="#ref-for-propdef-toggle-root①">2. 
 Toggle Concepts</a>
     <li><a href="#ref-for-propdef-toggle-root②">2.1. 
 Toggles and CSS Properties</a> <a href="#ref-for-propdef-toggle-root③">(2)</a>
     <li><a href="#ref-for-propdef-toggle-root④">3. 
-Creating a Toggle: the toggle-root property</a> <a href="#ref-for-propdef-toggle-root⑤">(2)</a> <a href="#ref-for-propdef-toggle-root⑥">(3)</a>
-    <li><a href="#ref-for-propdef-toggle-root⑦">3.3. 
-Creating and Activating Toggles Simultaneously: the toggle shorthand</a> <a href="#ref-for-propdef-toggle-root⑧">(2)</a> <a href="#ref-for-propdef-toggle-root⑨">(3)</a>
-    <li><a href="#ref-for-propdef-toggle-root①⓪">6. 
-Scripting API</a> <a href="#ref-for-propdef-toggle-root①①">(2)</a>
+Creating a Toggle: the toggle-root property</a> <a href="#ref-for-propdef-toggle-root⑤">(2)</a>
+    <li><a href="#ref-for-propdef-toggle-root⑥">3.1. 
+Toggle Creation Details</a> <a href="#ref-for-propdef-toggle-root⑦">(2)</a>
+    <li><a href="#ref-for-propdef-toggle-root⑧">3.4. 
+Creating and Activating Toggles Simultaneously: the toggle shorthand</a> <a href="#ref-for-propdef-toggle-root⑨">(2)</a> <a href="#ref-for-propdef-toggle-root①⓪">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="typedef-toggle-specifier">
@@ -2499,11 +2611,36 @@ Scripting API</a> <a href="#ref-for-propdef-toggle-root①①">(2)</a>
 Creating a Toggle: the toggle-root property</a> <a href="#ref-for-typedef-toggle-specifier①">(2)</a> <a href="#ref-for-typedef-toggle-specifier②">(3)</a> <a href="#ref-for-typedef-toggle-specifier③">(4)</a> <a href="#ref-for-typedef-toggle-specifier④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-toggle-root-sticky">
-   <b><a href="#valdef-toggle-root-sticky">#valdef-toggle-root-sticky</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="typedef-toggle-states">
+   <b><a href="#typedef-toggle-states">#typedef-toggle-states</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-valdef-toggle-root-sticky">3.1. 
-Linking Toggle States: the toggle-group property</a>
+    <li><a href="#ref-for-typedef-toggle-states">3. 
+Creating a Toggle: the toggle-root property</a> <a href="#ref-for-typedef-toggle-states①">(2)</a> <a href="#ref-for-typedef-toggle-states②">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="typedef-toggle-state">
+   <b><a href="#typedef-toggle-state">#typedef-toggle-state</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-typedef-toggle-state">3. 
+Creating a Toggle: the toggle-root property</a> <a href="#ref-for-typedef-toggle-state①">(2)</a> <a href="#ref-for-typedef-toggle-state②">(3)</a>
+    <li><a href="#ref-for-typedef-toggle-state③">3.3. 
+Activating a Toggle: the toggle-trigger property</a> <a href="#ref-for-typedef-toggle-state④">(2)</a>
+    <li><a href="#ref-for-typedef-toggle-state⑤">4. 
+Selecting Elements Based on Toggle State: the :toggle() pseudo-class</a> <a href="#ref-for-typedef-toggle-state⑥">(2)</a> <a href="#ref-for-typedef-toggle-state⑦">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="typedef-toggle-overflow">
+   <b><a href="#typedef-toggle-overflow">#typedef-toggle-overflow</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-typedef-toggle-overflow">3. 
+Creating a Toggle: the toggle-root property</a> <a href="#ref-for-typedef-toggle-overflow①">(2)</a> <a href="#ref-for-typedef-toggle-overflow②">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="element-established-toggles">
+   <b><a href="#element-established-toggles">#element-established-toggles</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-element-established-toggles">6. 
+Scripting API</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="propdef-toggle-group">
@@ -2511,32 +2648,38 @@ Linking Toggle States: the toggle-group property</a>
    <ul>
     <li><a href="#ref-for-propdef-toggle-group">2. 
 Toggle Concepts</a>
-    <li><a href="#ref-for-propdef-toggle-group①">3.1. 
+    <li><a href="#ref-for-propdef-toggle-group①">3.2. 
 Linking Toggle States: the toggle-group property</a> <a href="#ref-for-propdef-toggle-group②">(2)</a> <a href="#ref-for-propdef-toggle-group③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-toggle-group-toggle-name">
-   <b><a href="#valdef-toggle-group-toggle-name">#valdef-toggle-group-toggle-name</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="valdef-toggle-group-custom-ident">
+   <b><a href="#valdef-toggle-group-custom-ident">#valdef-toggle-group-custom-ident</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-valdef-toggle-group-toggle-name">3.1. 
+    <li><a href="#ref-for-valdef-toggle-group-custom-ident">3.2. 
 Linking Toggle States: the toggle-group property</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="propdef-toggle-trigger">
    <b><a href="#propdef-toggle-trigger">#propdef-toggle-trigger</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-propdef-toggle-trigger">1. 
-Introduction</a>
+    <li><a href="#ref-for-propdef-toggle-trigger">1.1. Terminology</a>
     <li><a href="#ref-for-propdef-toggle-trigger①">2.1. 
 Toggles and CSS Properties</a>
-    <li><a href="#ref-for-propdef-toggle-trigger②">3.1. 
+    <li><a href="#ref-for-propdef-toggle-trigger②">3.2. 
 Linking Toggle States: the toggle-group property</a>
-    <li><a href="#ref-for-propdef-toggle-trigger③">3.2. 
+    <li><a href="#ref-for-propdef-toggle-trigger③">3.3. 
 Activating a Toggle: the toggle-trigger property</a> <a href="#ref-for-propdef-toggle-trigger④">(2)</a>
-    <li><a href="#ref-for-propdef-toggle-trigger⑤">3.3. 
+    <li><a href="#ref-for-propdef-toggle-trigger⑤">3.4. 
 Creating and Activating Toggles Simultaneously: the toggle shorthand</a> <a href="#ref-for-propdef-toggle-trigger⑥">(2)</a>
-    <li><a href="#ref-for-propdef-toggle-trigger⑦">3.4. 
+    <li><a href="#ref-for-propdef-toggle-trigger⑦">3.5. 
 Accessibility Implications of Toggles</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="typedef-trigger-action">
+   <b><a href="#typedef-trigger-action">#typedef-trigger-action</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-typedef-trigger-action">3.3. 
+Activating a Toggle: the toggle-trigger property</a> <a href="#ref-for-typedef-trigger-action①">(2)</a> <a href="#ref-for-typedef-trigger-action②">(3)</a> <a href="#ref-for-typedef-trigger-action③">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="valdef-toggle-trigger-none">
@@ -2551,7 +2694,7 @@ Toggles and CSS Properties</a>
    <ul>
     <li><a href="#ref-for-css-toggle-activation">2. 
 Toggle Concepts</a> <a href="#ref-for-css-toggle-activation①">(2)</a>
-    <li><a href="#ref-for-css-toggle-activation②">3.2. 
+    <li><a href="#ref-for-css-toggle-activation②">3.3. 
 Activating a Toggle: the toggle-trigger property</a> <a href="#ref-for-css-toggle-activation③">(2)</a>
     <li><a href="#ref-for-css-toggle-activation④">5. 
 Automatically Hiding With A Toggle</a>
@@ -2560,25 +2703,25 @@ Automatically Hiding With A Toggle</a>
   <aside class="dfn-panel" data-for="toggle-activation-name">
    <b><a href="#toggle-activation-name">#toggle-activation-name</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-toggle-activation-name">3.2. 
-Activating a Toggle: the toggle-trigger property</a>
-    <li><a href="#ref-for-toggle-activation-name①">5. 
+    <li><a href="#ref-for-toggle-activation-name">3.3. 
+Activating a Toggle: the toggle-trigger property</a> <a href="#ref-for-toggle-activation-name①">(2)</a>
+    <li><a href="#ref-for-toggle-activation-name②">5. 
 Automatically Hiding With A Toggle</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="toggle-activation-target-state">
-   <b><a href="#toggle-activation-target-state">#toggle-activation-target-state</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="toggle-activation-event">
+   <b><a href="#toggle-activation-event">#toggle-activation-event</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-toggle-activation-target-state">3.2. 
-Activating a Toggle: the toggle-trigger property</a> <a href="#ref-for-toggle-activation-target-state①">(2)</a>
-    <li><a href="#ref-for-toggle-activation-target-state②">5. 
+    <li><a href="#ref-for-toggle-activation-event">3.3. 
+Activating a Toggle: the toggle-trigger property</a>
+    <li><a href="#ref-for-toggle-activation-event①">5. 
 Automatically Hiding With A Toggle</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="fire-a-toggle-activation">
    <b><a href="#fire-a-toggle-activation">#fire-a-toggle-activation</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-fire-a-toggle-activation">3.2. 
+    <li><a href="#ref-for-fire-a-toggle-activation">3.3. 
 Activating a Toggle: the toggle-trigger property</a>
     <li><a href="#ref-for-fire-a-toggle-activation①">5. 
 Automatically Hiding With A Toggle</a>
@@ -2587,15 +2730,14 @@ Automatically Hiding With A Toggle</a>
   <aside class="dfn-panel" data-for="propdef-toggle">
    <b><a href="#propdef-toggle">#propdef-toggle</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-propdef-toggle">3.3. 
+    <li><a href="#ref-for-propdef-toggle">3.4. 
 Creating and Activating Toggles Simultaneously: the toggle shorthand</a> <a href="#ref-for-propdef-toggle①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="selectordef-toggle">
    <b><a href="#selectordef-toggle">#selectordef-toggle</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-selectordef-toggle">1. 
-Introduction</a> <a href="#ref-for-selectordef-toggle①">(2)</a>
+    <li><a href="#ref-for-selectordef-toggle">1.1. Terminology</a> <a href="#ref-for-selectordef-toggle①">(2)</a>
     <li><a href="#ref-for-selectordef-toggle②">2.1. 
 Toggles and CSS Properties</a>
     <li><a href="#ref-for-selectordef-toggle③">4. 
@@ -2605,10 +2747,54 @@ Selecting Elements Based on Toggle State: the :toggle() pseudo-class</a> <a href
   <aside class="dfn-panel" data-for="propdef-toggle-visibility">
    <b><a href="#propdef-toggle-visibility">#propdef-toggle-visibility</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-propdef-toggle-visibility">3.4. 
+    <li><a href="#ref-for-propdef-toggle-visibility">3.5. 
 Accessibility Implications of Toggles</a>
     <li><a href="#ref-for-propdef-toggle-visibility①">5. 
 Automatically Hiding With A Toggle</a> <a href="#ref-for-propdef-toggle-visibility②">(2)</a> <a href="#ref-for-propdef-toggle-visibility③">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-element-toggles">
+   <b><a href="#dom-element-toggles">#dom-element-toggles</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-element-toggles">3.1. 
+Toggle Creation Details</a>
+    <li><a href="#ref-for-dom-element-toggles①">6. 
+Scripting API</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="csstogglemap">
+   <b><a href="#csstogglemap">#csstogglemap</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-csstogglemap">6. 
+Scripting API</a> <a href="#ref-for-csstogglemap①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="csstoggle">
+   <b><a href="#csstoggle">#csstoggle</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-csstoggle">6. 
+Scripting API</a> <a href="#ref-for-csstoggle①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dictdef-csstoggledata">
+   <b><a href="#dictdef-csstoggledata">#dictdef-csstoggledata</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dictdef-csstoggledata">6. 
+Scripting API</a> <a href="#ref-for-dictdef-csstoggledata①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="enumdef-csstogglescope">
+   <b><a href="#enumdef-csstogglescope">#enumdef-csstogglescope</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-enumdef-csstogglescope">6. 
+Scripting API</a> <a href="#ref-for-enumdef-csstogglescope①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="enumdef-csstogglecycle">
+   <b><a href="#enumdef-csstogglecycle">#enumdef-csstogglecycle</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-enumdef-csstogglecycle">6. 
+Scripting API</a> <a href="#ref-for-enumdef-csstogglecycle①">(2)</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
   <link href="https://www.w3.org/2008/site/images/favicon.ico" rel="icon">
   <meta content="Bikeshed version dfbc2b297, updated Thu Nov 11 15:52:32 2021 -0800" name="generator">
   <link href="http://tabatkins.github.io/css-toggle/" rel="canonical">
-  <meta content="0fab36fead319242a7406d3b0604c5d21ece68de" name="document-revision">
+  <meta content="bedad336fdd537cd4266273c87d06f58b70f77f7" name="document-revision">
 <style>/* style-autolinks */
 
 .css.css, .property.property, .descriptor.descriptor {
@@ -905,11 +905,12 @@ and decrementing below 0 returns the toggle to the <span id="ref-for-toggle-spec
       <li data-md>
        <p>For "sticky",
 incrementing beyond the <a data-link-type="dfn" href="#toggle-specifier-maximum-state" id="ref-for-toggle-specifier-maximum-state⑤">maximum state</a> or decrementing below 0
-does not change the toggle state.</p>
+does not change the <a data-link-type="dfn" href="#toggle-state" id="ref-for-toggle-state⑧">state</a>.</p>
       <li data-md>
-       <p>If the <a data-link-type="dfn" href="#toggle-state" id="ref-for-toggle-state⑧">state</a> before activation is an <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#integer-value" id="ref-for-integer-value⑦">&lt;integer></a> that is higher than the <a data-link-type="dfn" href="#toggle-specifier-maximum-state" id="ref-for-toggle-specifier-maximum-state⑥">maximum state</a>,
+       <p>If the <a data-link-type="dfn" href="#toggle-state" id="ref-for-toggle-state⑨">state</a> before activation is an <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#integer-value" id="ref-for-integer-value⑦">&lt;integer></a> that is higher than the <a data-link-type="dfn" href="#toggle-specifier-maximum-state" id="ref-for-toggle-specifier-maximum-state⑥">maximum state</a>,
 or a <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#identifier-value" id="ref-for-identifier-value①⑤">&lt;custom-ident></a> that is not in the list of <a data-link-type="dfn" href="#toggle-specifier-state-names" id="ref-for-toggle-specifier-state-names">state names</a>,
-then both incrementing and decrementing follow the specified.</p>
+then incrementing follows the specified overflow behavior,
+and decrementing returns the toggle to the <span id="ref-for-toggle-specifier-maximum-state⑦">maximum state</span>.</p>
      </ul>
    </dl>
    <p><a data-link-type="dfn" href="#toggle-toggle-specifier" id="ref-for-toggle-toggle-specifier">Toggle specifiers</a> are created by the <a class="property" data-link-type="propdesc" href="#propdef-toggle-root" id="ref-for-propdef-toggle-root①">toggle-root</a> property;
@@ -921,7 +922,7 @@ then both incrementing and decrementing follow the specified.</p>
 		a <a data-link-type="dfn" href="#toggle-specifier-state-names" id="ref-for-toggle-specifier-state-names①">state names</a> of an empty <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list②">list</a>,
 		a false <a data-link-type="dfn" href="#toggle-specifier-group" id="ref-for-toggle-specifier-group">group</a>,
 		a <a data-link-type="dfn" href="#toggle-specifier-scope" id="ref-for-toggle-specifier-scope">scope</a> of "wide",
-		a <a data-link-type="dfn" href="#toggle-specifier-maximum-state" id="ref-for-toggle-specifier-maximum-state⑦">maximum state</a> of 1,
+		a <a data-link-type="dfn" href="#toggle-specifier-maximum-state" id="ref-for-toggle-specifier-maximum-state⑧">maximum state</a> of 1,
 		and a <a data-link-type="dfn" href="#toggle-specifier-overflow" id="ref-for-toggle-specifier-overflow">overflow</a> of "cycle". 
     <p class="note" role="note"><span>Note:</span> This produces behavior similar to a checkbox.</p>
    </div>
@@ -1032,11 +1033,11 @@ then both incrementing and decrementing follow the specified.</p>
 as the item’s value.</p>
       <li data-md>
        <p>The <a class="production css" data-link-type="type" href="#typedef-toggle-states" id="ref-for-typedef-toggle-states②">&lt;toggle-states></a>, if specified as an <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#integer-value" id="ref-for-integer-value①⓪">&lt;integer></a>,
-specifies the <a data-link-type="dfn" href="#toggle-specifier-maximum-state" id="ref-for-toggle-specifier-maximum-state⑧">maximum state</a>.
+specifies the <a data-link-type="dfn" href="#toggle-specifier-maximum-state" id="ref-for-toggle-specifier-maximum-state⑨">maximum state</a>.
 If specified as a bracketed list of <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#identifier-value" id="ref-for-identifier-value②⓪">&lt;custom-ident></a>s,
 specifies the <a data-link-type="dfn" href="#toggle-specifier-state-names" id="ref-for-toggle-specifier-state-names②">state names</a>,
-and sets the <span id="ref-for-toggle-specifier-maximum-state⑨">maximum state</span> to the (zero-indexed) length of the list.
-If omitted, the <span id="ref-for-toggle-specifier-maximum-state①⓪">maximum state</span> is set to 1.</p>
+and sets the <span id="ref-for-toggle-specifier-maximum-state①⓪">maximum state</span> to the length of the list minus 1.
+If omitted, the <span id="ref-for-toggle-specifier-maximum-state①①">maximum state</span> is set to 1.</p>
       <li data-md>
        <p>The <a class="production css" data-link-type="type" href="#typedef-toggle-state" id="ref-for-typedef-toggle-state②">&lt;toggle-state></a>, if specified,
 specifies the <a data-link-type="dfn" href="#toggle-specifier-initial-state" id="ref-for-toggle-specifier-initial-state①">initial state</a>.
@@ -1117,7 +1118,7 @@ If omitted, it’s set to "wide".</p>
       <th><a href="https://www.w3.org/TR/web-animations/#animation-type">Animatable:</a>
       <td>no 
    </table>
-   <p>By default, each <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle③①">toggle’s</a> <a data-link-type="dfn" href="#toggle-state" id="ref-for-toggle-state⑨">state</a> is independent;
+   <p>By default, each <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle③①">toggle’s</a> <a data-link-type="dfn" href="#toggle-state" id="ref-for-toggle-state①⓪">state</a> is independent;
 	incrementing one has no effect an any other.
 	The <a class="property" data-link-type="propdesc" href="#propdef-toggle-group" id="ref-for-propdef-toggle-group②">toggle-group</a> property allows elements to link their <span id="ref-for-css-toggle③②">toggles</span> together:
 	all <span id="ref-for-css-toggle③③">toggles</span> with the same <a data-link-type="dfn" href="#toggle-name" id="ref-for-toggle-name⑥">name</a> as the <a data-link-type="dfn" href="#css-toggle-group" id="ref-for-css-toggle-group①④">toggle group</a> that are on elements <a data-link-type="dfn" href="#toggle-in-scope" id="ref-for-toggle-in-scope②">in scope</a> for the <span id="ref-for-css-toggle-group①⑤">toggle group</span> are linked,
@@ -1181,11 +1182,11 @@ If omitted, it’s set to "wide".</p>
 <c- p>}</c->
 <c- p>&lt;/</c-><c- f>style</c-><c- p>></c->
 </pre>
-    <p>Clicking on any tab will increment its corresponding <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle③⑤">toggle’s</a> <a data-link-type="dfn" href="#toggle-state" id="ref-for-toggle-state①⓪">state</a> from 0 to 1
+    <p>Clicking on any tab will increment its corresponding <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle③⑤">toggle’s</a> <a data-link-type="dfn" href="#toggle-state" id="ref-for-toggle-state①①">state</a> from 0 to 1
 		(and the <span class="css">cycle-on</span> keyword will keep it at 1 if activated multiple times),
-		while resetting the rest of the tabs' <span id="ref-for-toggle-state①①">states</span> to 0.
+		while resetting the rest of the tabs' <span id="ref-for-toggle-state①②">states</span> to 0.
 		Each panel is <a data-link-type="dfn" href="#toggle-in-scope" id="ref-for-toggle-in-scope③">in scope</a> for the <span id="ref-for-css-toggle③⑥">toggle</span> defined by its preceding tab,
-		so it can respond to the <span id="ref-for-toggle-state①②">state</span> as well.</p>
+		so it can respond to the <span id="ref-for-toggle-state①③">state</span> as well.</p>
    </div>
    <div class="issue" id="issue-47da3fb8">
     <a class="self-link" href="#issue-47da3fb8"></a> Radio buttons have one particular tabbing/switching/activation behavior
@@ -1235,7 +1236,7 @@ If omitted, it’s set to "wide".</p>
    </table>
 <pre class="prod"><df><a class="production" data-link-type="type">&lt;toggle-trigger></a> = <a class="production" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#identifier-value" id="ref-for-identifier-value②④">&lt;custom-ident></a> <a class="production" data-link-type="type" href="#typedef-trigger-action" id="ref-for-typedef-trigger-action">&lt;trigger-action></a><a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#mult-opt" id="ref-for-mult-opt③">?</a>
 <dfn class="dfn-paneled" data-dfn-type="type" data-export id="typedef-trigger-action"><a class="production" data-link-type="type" href="#typedef-trigger-action" id="ref-for-typedef-trigger-action①">&lt;trigger-action></a></dfn> =
-  prev <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one" id="ref-for-comb-one⑦">|</a> next <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one" id="ref-for-comb-one⑧">|</a>
+  [prev <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one" id="ref-for-comb-one⑦">|</a> next] <a class="production" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#integer-value" id="ref-for-integer-value①①">&lt;integer [1,∞]></a><a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#mult-opt" id="ref-for-mult-opt④">?</a> <a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#comb-one" id="ref-for-comb-one⑧">|</a>
   set <a class="production" data-link-type="type" href="#typedef-toggle-state" id="ref-for-typedef-toggle-state③">&lt;toggle-state></a>
 </df></pre>
    <p>The <a class="property" data-link-type="propdesc" href="#propdef-toggle-trigger" id="ref-for-propdef-toggle-trigger④">toggle-trigger</a> property specifies that an element can be activated
@@ -1268,12 +1269,14 @@ and the <a class="production css" data-link-type="type" href="#typedef-trigger-a
     <dd data-md>
      <p>If unspecified, or specified as the keyword <a class="property" data-link-type="propdesc">next</a>,
 indicates that this activation will increment
-the <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle④⓪">toggle’s</a> current <a data-link-type="dfn" href="#toggle-state" id="ref-for-toggle-state①③">state</a>.
+the <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle④⓪">toggle’s</a> current <a data-link-type="dfn" href="#toggle-state" id="ref-for-toggle-state①④">state</a> by <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#integer-value" id="ref-for-integer-value①②">&lt;integer></a> steps,
+or a single step if <span class="production" id="ref-for-integer-value①③">&lt;integer></span> is not specified.
 If specified as the keyword <span class="property">prev</span>,
 indicates that this activation will decrement
-the <span id="ref-for-css-toggle④①">toggle’s</span> current <span id="ref-for-toggle-state①④">state</span>.
+the <span id="ref-for-css-toggle④①">toggle’s</span> current <span id="ref-for-toggle-state①⑤">state</span> by <span class="production" id="ref-for-integer-value①④">&lt;integer></span> steps,
+or a single step if <span class="production" id="ref-for-integer-value①⑤">&lt;integer></span> is not specified.
 If specified with the keyword <span class="property">set</span> and a <a class="production css" data-link-type="type" href="#typedef-toggle-state" id="ref-for-typedef-toggle-state④">&lt;toggle-state></a>,
-indicates the exact <span id="ref-for-toggle-state①⑤">state</span> that this activation will attempt to put the <span id="ref-for-css-toggle④②">toggle</span> into.</p>
+indicates the exact <span id="ref-for-toggle-state①⑥">state</span> that this activation will attempt to put the <span id="ref-for-css-toggle④②">toggle</span> into.</p>
    </dl>
    <div class="algorithm" data-algorithm="fire a toggle activation">
      To <dfn class="dfn-paneled" data-dfn-type="dfn" data-export data-local-lt="fire" id="fire-a-toggle-activation">fire a toggle activation</dfn> on an element <var>initial element</var> with a <a data-link-type="dfn" href="#css-toggle-activation" id="ref-for-css-toggle-activation③">toggle activation</a> <var>activation</var>: 
@@ -1292,15 +1295,15 @@ then:</p>
 let <var>specifier</var> be it.</p>
         <p>Otherwise, let <var>specifier</var> be a new <a data-link-type="dfn" href="#default-toggle-specifier" id="ref-for-default-toggle-specifier">default toggle specifier</a> for <var>activation</var>’s <a data-link-type="dfn" href="#toggle-activation-name" id="ref-for-toggle-activation-name①">name</a>.</p>
        <li data-md>
-        <p>Set <var>toggle</var>’s <a data-link-type="dfn" href="#toggle-state" id="ref-for-toggle-state①⑥">state</a> to the result of
+        <p>Set <var>toggle</var>’s <a data-link-type="dfn" href="#toggle-state" id="ref-for-toggle-state①⑦">state</a> to the result of
 the specified <a data-link-type="dfn" href="#toggle-activation-event" id="ref-for-toggle-activation-event">event</a>,
 following the specified <a data-link-type="dfn" href="#toggle-specifier-overflow" id="ref-for-toggle-specifier-overflow②">overflow</a> behavior
 when incrementing or decrementing.</p>
        <li data-md>
-        <p>If <var>toggle</var>’s <a data-link-type="dfn" href="#toggle-state" id="ref-for-toggle-state①⑦">state</a> is now greater than zero
+        <p>If <var>toggle</var>’s <a data-link-type="dfn" href="#toggle-state" id="ref-for-toggle-state①⑧">state</a> is now greater than zero
 and <var>toggle</var> is <a data-link-type="dfn" href="#toggle-in-a-toggle-group" id="ref-for-toggle-in-a-toggle-group①">in a toggle group</a>,
 then for each <em>other</em> <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle④⑥">toggle</a> in the same <a data-link-type="dfn" href="#css-toggle-group" id="ref-for-css-toggle-group①⑧">toggle group</a>,
-set their <span id="ref-for-toggle-state①⑧">state</span> to 0.</p>
+set their <span id="ref-for-toggle-state①⑨">state</span> to 0.</p>
        <li data-md>
         <p>Return from this algorithm.</p>
       </ol>
@@ -1408,12 +1411,12 @@ we can also automatically infer all the tab-set ARIA roles</p>
 	(as defined by the host language)
 	depending on their "checked" state.</p>
    <p><a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle⑤①">Toggles</a> provides a very similar functionality,
-	allowing elements to be selected based on their <span id="ref-for-css-toggle⑤②">toggle</span> <a data-link-type="dfn" href="#toggle-state" id="ref-for-toggle-state①⑨">state</a>,
+	allowing elements to be selected based on their <span id="ref-for-css-toggle⑤②">toggle</span> <a data-link-type="dfn" href="#toggle-state" id="ref-for-toggle-state②⓪">state</a>,
 	the <dfn class="dfn-paneled css" data-dfn-type="selector" data-export id="selectordef-toggle">:toggle()</dfn> pseudo-class:</p>
-<pre class="prod">:toggle( <a class="production" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#identifier-value" id="ref-for-identifier-value②⑥">&lt;custom-ident></a> <a class="production" data-link-type="type" href="#typedef-toggle-state" id="ref-for-typedef-toggle-state⑤">&lt;toggle-state></a><a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#mult-opt" id="ref-for-mult-opt④">?</a> )
+<pre class="prod">:toggle( <a class="production" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#identifier-value" id="ref-for-identifier-value②⑥">&lt;custom-ident></a> <a class="production" data-link-type="type" href="#typedef-toggle-state" id="ref-for-typedef-toggle-state⑤">&lt;toggle-state></a><a data-link-type="grammar" href="https://drafts.csswg.org/css-values-4/#mult-opt" id="ref-for-mult-opt⑤">?</a> )
 </pre>
    <p>An element matches <a class="css" data-link-type="maybe" href="#selectordef-toggle" id="ref-for-selectordef-toggle④">:toggle()</a> if the element is <a data-link-type="dfn" href="#toggle-in-scope" id="ref-for-toggle-in-scope⑤">in scope</a> for a <a data-link-type="dfn" href="#css-toggle" id="ref-for-css-toggle⑤③">toggle</a> with the <a data-link-type="dfn" href="#toggle-name" id="ref-for-toggle-name⑨">name</a> given by <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#identifier-value" id="ref-for-identifier-value②⑦">&lt;custom-ident></a>,
-	and either the <span id="ref-for-css-toggle⑤④">toggle’s</span> <a data-link-type="dfn" href="#toggle-state" id="ref-for-toggle-state②⓪">state</a> <a data-link-type="dfn" href="#toggle-match-state" id="ref-for-toggle-match-state">matches</a> the provided <a class="production css" data-link-type="type" href="#typedef-toggle-state" id="ref-for-typedef-toggle-state⑥">&lt;toggle-state></a>,
+	and either the <span id="ref-for-css-toggle⑤④">toggle’s</span> <a data-link-type="dfn" href="#toggle-state" id="ref-for-toggle-state②①">state</a> <a data-link-type="dfn" href="#toggle-match-state" id="ref-for-toggle-match-state">matches</a> the provided <a class="production css" data-link-type="type" href="#typedef-toggle-state" id="ref-for-typedef-toggle-state⑥">&lt;toggle-state></a>,
 	or the <span class="production" id="ref-for-typedef-toggle-state⑦">&lt;toggle-state></span> is omitted
 	and the <span id="ref-for-css-toggle⑤⑤">toggle</span> is in any <a data-link-type="dfn" href="#toggle-active-state" id="ref-for-toggle-active-state⑤">active state</a>.</p>
    <div class="example" id="example-d684b11f">
@@ -1597,6 +1600,7 @@ the element renders normally.</p>
 <c- b>enum</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="enum" data-export id="enumdef-csstogglecycle"><code><c- g>CSSToggleCycle</c-></code></dfn> {
   <dfn class="idl-code" data-dfn-for="CSSToggleCycle" data-dfn-type="enum-value" data-export id="dom-csstogglecycle-cycle"><code><c- s>"cycle"</c-></code><a class="self-link" href="#dom-csstogglecycle-cycle"></a></dfn>,
   <dfn class="idl-code" data-dfn-for="CSSToggleCycle" data-dfn-type="enum-value" data-export id="dom-csstogglecycle-cycle-on"><code><c- s>"cycle-on"</c-></code><a class="self-link" href="#dom-csstogglecycle-cycle-on"></a></dfn>,
+  <dfn class="idl-code" data-dfn-for="CSSToggleCycle" data-dfn-type="enum-value" data-export id="dom-csstogglecycle-sticky"><code><c- s>"sticky"</c-></code><a class="self-link" href="#dom-csstogglecycle-sticky"></a></dfn>,
 }
 </pre>
    <p>The <code class="idl"><a data-link-type="idl" href="#dom-element-toggles" id="ref-for-dom-element-toggles①">toggles</a></code> attribute on <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element①">Element</a></code>s
@@ -1783,6 +1787,7 @@ the element renders normally.</p>
      <li><a href="#toggle-state-names">dfn for toggle</a><span>, in § 2</span>
      <li><a href="#toggle-specifier-state-names">dfn for toggle specifier</a><span>, in § 2</span>
     </ul>
+   <li><a href="#dom-csstogglecycle-sticky">"sticky"</a><span>, in § 6</span>
    <li><a href="#selectordef-toggle">:toggle()</a><span>, in § 4</span>
    <li>
     toggle
@@ -1900,6 +1905,8 @@ Automatically Hiding With A Toggle</a> <a href="#ref-for-identifier-value②⑨"
 Toggle Concepts</a> <a href="#ref-for-integer-value①">(2)</a> <a href="#ref-for-integer-value②">(3)</a> <a href="#ref-for-integer-value③">(4)</a> <a href="#ref-for-integer-value④">(5)</a> <a href="#ref-for-integer-value⑤">(6)</a> <a href="#ref-for-integer-value⑥">(7)</a> <a href="#ref-for-integer-value⑦">(8)</a>
     <li><a href="#ref-for-integer-value⑧">3. 
 Creating a Toggle: the toggle-root property</a> <a href="#ref-for-integer-value⑨">(2)</a> <a href="#ref-for-integer-value①⓪">(3)</a>
+    <li><a href="#ref-for-integer-value①①">3.3. 
+Activating a Toggle: the toggle-trigger property</a> <a href="#ref-for-integer-value①②">(2)</a> <a href="#ref-for-integer-value①③">(3)</a> <a href="#ref-for-integer-value①④">(4)</a> <a href="#ref-for-integer-value①⑤">(5)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-mult-opt">
@@ -1910,8 +1917,8 @@ Creating a Toggle: the toggle-root property</a> <a href="#ref-for-mult-opt①">(
     <li><a href="#ref-for-mult-opt②">3.2. 
 Linking Toggle States: the toggle-group property</a>
     <li><a href="#ref-for-mult-opt③">3.3. 
-Activating a Toggle: the toggle-trigger property</a>
-    <li><a href="#ref-for-mult-opt④">4. 
+Activating a Toggle: the toggle-trigger property</a> <a href="#ref-for-mult-opt④">(2)</a>
+    <li><a href="#ref-for-mult-opt⑤">4. 
 Selecting Elements Based on Toggle State: the :toggle() pseudo-class</a>
    </ul>
   </aside>
@@ -2268,6 +2275,7 @@ Scripting API</a> <a href="#ref-for-idl-DOMString①">(2)</a>
 <c- b>enum</c-> <a href="#enumdef-csstogglecycle"><code><c- g>CSSToggleCycle</c-></code></a> {
   <a href="#dom-csstogglecycle-cycle"><code><c- s>"cycle"</c-></code></a>,
   <a href="#dom-csstogglecycle-cycle-on"><code><c- s>"cycle-on"</c-></code></a>,
+  <a href="#dom-csstogglecycle-sticky"><code><c- s>"sticky"</c-></code></a>,
 }
 
 </pre>
@@ -2371,13 +2379,13 @@ Selecting Elements Based on Toggle State: the :toggle() pseudo-class</a>
    <b><a href="#toggle-state">#toggle-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-toggle-state">2. 
-Toggle Concepts</a> <a href="#ref-for-toggle-state①">(2)</a> <a href="#ref-for-toggle-state②">(3)</a> <a href="#ref-for-toggle-state③">(4)</a> <a href="#ref-for-toggle-state④">(5)</a> <a href="#ref-for-toggle-state⑤">(6)</a> <a href="#ref-for-toggle-state⑥">(7)</a> <a href="#ref-for-toggle-state⑦">(8)</a> <a href="#ref-for-toggle-state⑧">(9)</a>
-    <li><a href="#ref-for-toggle-state⑨">3.2. 
-Linking Toggle States: the toggle-group property</a> <a href="#ref-for-toggle-state①⓪">(2)</a> <a href="#ref-for-toggle-state①①">(3)</a> <a href="#ref-for-toggle-state①②">(4)</a>
-    <li><a href="#ref-for-toggle-state①③">3.3. 
-Activating a Toggle: the toggle-trigger property</a> <a href="#ref-for-toggle-state①④">(2)</a> <a href="#ref-for-toggle-state①⑤">(3)</a> <a href="#ref-for-toggle-state①⑥">(4)</a> <a href="#ref-for-toggle-state①⑦">(5)</a> <a href="#ref-for-toggle-state①⑧">(6)</a>
-    <li><a href="#ref-for-toggle-state①⑨">4. 
-Selecting Elements Based on Toggle State: the :toggle() pseudo-class</a> <a href="#ref-for-toggle-state②⓪">(2)</a>
+Toggle Concepts</a> <a href="#ref-for-toggle-state①">(2)</a> <a href="#ref-for-toggle-state②">(3)</a> <a href="#ref-for-toggle-state③">(4)</a> <a href="#ref-for-toggle-state④">(5)</a> <a href="#ref-for-toggle-state⑤">(6)</a> <a href="#ref-for-toggle-state⑥">(7)</a> <a href="#ref-for-toggle-state⑦">(8)</a> <a href="#ref-for-toggle-state⑧">(9)</a> <a href="#ref-for-toggle-state⑨">(10)</a>
+    <li><a href="#ref-for-toggle-state①⓪">3.2. 
+Linking Toggle States: the toggle-group property</a> <a href="#ref-for-toggle-state①①">(2)</a> <a href="#ref-for-toggle-state①②">(3)</a> <a href="#ref-for-toggle-state①③">(4)</a>
+    <li><a href="#ref-for-toggle-state①④">3.3. 
+Activating a Toggle: the toggle-trigger property</a> <a href="#ref-for-toggle-state①⑤">(2)</a> <a href="#ref-for-toggle-state①⑥">(3)</a> <a href="#ref-for-toggle-state①⑦">(4)</a> <a href="#ref-for-toggle-state①⑧">(5)</a> <a href="#ref-for-toggle-state①⑨">(6)</a>
+    <li><a href="#ref-for-toggle-state②⓪">4. 
+Selecting Elements Based on Toggle State: the :toggle() pseudo-class</a> <a href="#ref-for-toggle-state②①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="toggle-inactive-state">
@@ -2538,9 +2546,9 @@ Creating a Toggle: the toggle-root property</a>
    <b><a href="#toggle-specifier-maximum-state">#toggle-specifier-maximum-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-toggle-specifier-maximum-state">2. 
-Toggle Concepts</a> <a href="#ref-for-toggle-specifier-maximum-state①">(2)</a> <a href="#ref-for-toggle-specifier-maximum-state②">(3)</a> <a href="#ref-for-toggle-specifier-maximum-state③">(4)</a> <a href="#ref-for-toggle-specifier-maximum-state④">(5)</a> <a href="#ref-for-toggle-specifier-maximum-state⑤">(6)</a> <a href="#ref-for-toggle-specifier-maximum-state⑥">(7)</a> <a href="#ref-for-toggle-specifier-maximum-state⑦">(8)</a>
-    <li><a href="#ref-for-toggle-specifier-maximum-state⑧">3. 
-Creating a Toggle: the toggle-root property</a> <a href="#ref-for-toggle-specifier-maximum-state⑨">(2)</a> <a href="#ref-for-toggle-specifier-maximum-state①⓪">(3)</a>
+Toggle Concepts</a> <a href="#ref-for-toggle-specifier-maximum-state①">(2)</a> <a href="#ref-for-toggle-specifier-maximum-state②">(3)</a> <a href="#ref-for-toggle-specifier-maximum-state③">(4)</a> <a href="#ref-for-toggle-specifier-maximum-state④">(5)</a> <a href="#ref-for-toggle-specifier-maximum-state⑤">(6)</a> <a href="#ref-for-toggle-specifier-maximum-state⑥">(7)</a> <a href="#ref-for-toggle-specifier-maximum-state⑦">(8)</a> <a href="#ref-for-toggle-specifier-maximum-state⑧">(9)</a>
+    <li><a href="#ref-for-toggle-specifier-maximum-state⑨">3. 
+Creating a Toggle: the toggle-root property</a> <a href="#ref-for-toggle-specifier-maximum-state①⓪">(2)</a> <a href="#ref-for-toggle-specifier-maximum-state①①">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="toggle-specifier-state-names">


### PR DESCRIPTION
This maybe could have broken down into smaller PRs, but starting from 'named states', all these other changes seemed relevant. 

- Add support for `[list of named states]`
- Switch root syntax to `<states> at <initial>`
- Support additional 'overflow' options: `cycle`, `cycle-on`, `sticky`
- Switch trigger syntax to `next | prev | set <state>`
- Define how named/integer states 'match'
- Allow out-of-bounds states to be set explicitly, and define increment/decrement behavior

I'm not sure I made all the best choices in terms of where different aspects of the logic are defined. But it's a draft…